### PR TITLE
Added support to vm::vector for configurable header sizes (including …

### DIFF
--- a/include/psi/vm/mapping/mapping.posix.hpp
+++ b/include/psi/vm/mapping/mapping.posix.hpp
@@ -40,6 +40,8 @@ struct [[ clang::trivial_abi ]] mapping
 
     static bool constexpr retains_parent_handle              = false;
     static bool constexpr create_mapping_can_set_source_size = false;
+    static bool constexpr supports_zero_sized_mappings       = true ; // simply because there is actually no intermediate mapping object
+    static bool constexpr supports_zero_sized_views          = false;
 
     constexpr mapping(            ) noexcept = default;
     constexpr mapping( mapping && ) noexcept = default;

--- a/include/psi/vm/mapping/mapping.win32.hpp
+++ b/include/psi/vm/mapping/mapping.win32.hpp
@@ -41,8 +41,10 @@ struct [[ clang::trivial_abi ]] mapping
     using       handle = handle_ref<mapping, false>;
     using const_handle = handle_ref<mapping, true >;
 
-    static bool constexpr retains_parent_handle              = true;
-    static bool constexpr create_mapping_can_set_source_size = true;
+    static bool constexpr retains_parent_handle              = true ;
+    static bool constexpr create_mapping_can_set_source_size = true ;
+    static bool constexpr supports_zero_sized_mappings       = false; // Windows does not support zero sized mappings
+    static bool constexpr supports_zero_sized_views          = false;
 
     constexpr mapping(            ) noexcept = default;
     constexpr mapping( mapping && ) noexcept = default;

--- a/src/mappable_objects/file/file.win32.cpp
+++ b/src/mappable_objects/file/file.win32.cpp
@@ -116,7 +116,7 @@ namespace detail
         HANDLE map_file( file_handle::reference const file, flags::flags_t const flags, std::uint64_t const size ) noexcept
         {
             HANDLE handle{ handle_traits::invalid_value };
-            LARGE_INTEGER maximum_size{ .QuadPart = static_cast<LONGLONG>( std::max( 1ULL, size ) ) };
+            LARGE_INTEGER maximum_size{ .QuadPart = static_cast<LONGLONG>( size ) };
             auto const nt_result
             {
                 nt::NtCreateSection // TODO use it for named sections also


### PR DESCRIPTION
…headerless operation).

Fixed vector::assign() to actually shrink its size (w/ a downsizing assign).
Improved logic around zero sized mappings.