### PR TITLE
memory backed vectors

### DIFF
--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -16,7 +16,7 @@ TEST( vector, playground )
     std::filesystem::remove( test_vec );
     {
         psi::vm::vector< double, std::uint16_t > vec;
-        vec.open( test_vec.c_str() );
+        vec.map_file( test_vec.c_str() );
         EXPECT_EQ( vec.size(), 0 );
         vec.append_range({ 3.14, 0.14, 0.04 });
         EXPECT_EQ( vec.size(), 3 );
@@ -26,7 +26,7 @@ TEST( vector, playground )
     }
     {
         psi::vm::vector< double, std::uint16_t > vec;
-        vec.open( test_vec.c_str() );
+        vec.map_file( test_vec.c_str() );
         EXPECT_EQ( vec.size(), 3 );
         EXPECT_EQ( vec[ 0 ], 3.14 );
         EXPECT_EQ( vec[ 1 ], 0.14 );

--- a/vm.cmake
+++ b/vm.cmake
@@ -1,6 +1,8 @@
 # https://gitlab.kitware.com/cmake/cmake/-/issues/25725
 if ( CMAKE_CXX_COMPILER_ID MATCHES Clang AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT MATCHES MSVC )
     add_compile_options( $<$<COMPILE_LANGUAGE:CXX>:/clang:-std=gnu++2b> )
+elseif( MSVC ) # :wat: :wat: suddenly stopped 'recognizing' CMAKE_CXX_STANDARD !?
+    add_compile_options( /std:c++latest )
 else()
     set( CMAKE_CXX_STANDARD 26 )
 endif()


### PR DESCRIPTION
Added ability to create/allocate vm::vectors backed by pure virtual (anonymous) memory (instead of a file).
Added functions explicitly growing or shrinking a vector.