### PR TITLE
Changed size getters to allow/handle 'null' handles (and return zero)…

### DIFF
--- a/include/psi/vm/containers/vm_vector.hpp
+++ b/include/psi/vm/containers/vm_vector.hpp
@@ -80,6 +80,8 @@ public:
 
     [[ nodiscard, gnu::pure ]] bool has_attached_storage() const noexcept { return static_cast<bool>( mapping_ ); }
 
+    auto underlying_file() const noexcept { return mapping_.underlying_file(); }
+
     explicit operator bool() const noexcept { return has_attached_storage(); }
 
     void swap( contiguous_storage_base & other ) noexcept { std::swap( *this, other ); }

--- a/include/psi/vm/handles/handle_ref.hpp
+++ b/include/psi/vm/handles/handle_ref.hpp
@@ -3,7 +3,7 @@
 /// \file handle_ref.hpp
 /// --------------------
 ///
-/// Copyright (c) Domagoj Saric 2011 - 2024.
+/// Copyright (c) Domagoj Saric 2011 - 2025.
 ///
 /// Use, modification and distribution is subject to the
 /// Boost Software License, Version 1.0.
@@ -14,14 +14,9 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 //------------------------------------------------------------------------------
-#ifndef handle_ref_hpp__19A59763_A268_458C_932F_4E42DEA27751
-#define handle_ref_hpp__19A59763_A268_458C_932F_4E42DEA27751
 #pragma once
 //------------------------------------------------------------------------------
-namespace psi
-{
-//------------------------------------------------------------------------------
-namespace vm
+namespace psi::vm
 {
 //------------------------------------------------------------------------------
 
@@ -42,11 +37,13 @@ struct handle_ref
     constexpr handle_ref( Handle                &       handle ) noexcept                       : value{ handle.get() } {}
     constexpr handle_ref( Handle                &&      handle ) noexcept                       : value{ handle.get() } {}
 
-    template < bool other_read_only >
+    template <bool other_read_only>
     constexpr handle_ref( handle_ref<Handle, other_read_only> const mutable_ref ) noexcept requires( !other_read_only && read_only ) : value{ mutable_ref.value } {}
 
     constexpr          native_handle_t get() const noexcept requires( !read_only ) { return value; }
     constexpr operator native_handle_t    () const noexcept requires( !read_only ) { return value; }
+
+    [[ gnu::pure ]] explicit operator bool() const noexcept { return value != Handle::invalid_value; }
 
     [[ gnu::pure ]] constexpr bool operator==( native_handle_t const other ) const noexcept { return value == other; }
 
@@ -58,8 +55,5 @@ struct handle_ref
 #endif // _MSC_VER
 
 //------------------------------------------------------------------------------
-} // namespace vm
+} // namespace psi::vm
 //------------------------------------------------------------------------------
-} // namespace psi
-//------------------------------------------------------------------------------
-#endif // handle_ref_hpp

--- a/include/psi/vm/mappable_objects/file/file.win32.hpp
+++ b/include/psi/vm/mappable_objects/file/file.win32.hpp
@@ -38,8 +38,8 @@ bool        delete_file( char    const * file_name                 ) noexcept;
 bool        delete_file( wchar_t const * file_name                 ) noexcept;
 
 
-err::fallible_result<void, error> set_size( file_handle::reference, std::uint64_t desired_size ) noexcept;
-std::uint64_t                     get_size( file_handle::reference                             ) noexcept;
+err::fallible_result<void, error> set_size( file_handle::      reference, std::uint64_t desired_size ) noexcept;
+std::uint64_t                     get_size( file_handle::const_reference                             ) noexcept;
 
 // https://msdn.microsoft.com/en-us/library/ms810613.aspx Managing Memory-Mapped Files
 

--- a/include/psi/vm/mapping/mapping.posix.hpp
+++ b/include/psi/vm/mapping/mapping.posix.hpp
@@ -62,8 +62,8 @@ struct [[ clang::trivial_abi ]] mapping
 
     bool is_anonymous() const noexcept { return view_mapping_flags.flags & MAP_ANONYMOUS; }
 
-    posix::handle::      reference underlying_file()       noexcept { BOOST_ASSERT( is_file_based() ); return *this; }
-    posix::handle::const_reference underlying_file() const noexcept { BOOST_ASSERT( is_file_based() ); return *this; }
+    posix::handle::      reference underlying_file()       noexcept { return *this; }
+    posix::handle::const_reference underlying_file() const noexcept { return *this; }
 
     constexpr mapping & operator=( mapping && source ) noexcept
     {

--- a/include/psi/vm/mapping/mapping.win32.hpp
+++ b/include/psi/vm/mapping/mapping.win32.hpp
@@ -64,8 +64,8 @@ struct [[ clang::trivial_abi ]] mapping
 
     bool is_file_based() const noexcept { return static_cast<bool>( file ); }
 
-    file_handle::      reference underlying_file()       noexcept { BOOST_ASSERT( is_file_based() ); return file; }
-    file_handle::const_reference underlying_file() const noexcept { BOOST_ASSERT( is_file_based() ); return file; }
+    file_handle::      reference underlying_file()       noexcept { return file; }
+    file_handle::const_reference underlying_file() const noexcept { return file; }
 
     void operator=( mapping && source ) noexcept
     {

--- a/src/mappable_objects/file/file.win32.cpp
+++ b/src/mappable_objects/file/file.win32.cpp
@@ -94,10 +94,10 @@ err::fallible_result<void, error> set_size( file_handle::reference const file_ha
 }
 
 
-std::uint64_t get_size( file_handle::reference const file_handle ) noexcept
+std::uint64_t get_size( file_handle::const_reference const file_handle ) noexcept
 {
-    LARGE_INTEGER file_size;
-    BOOST_VERIFY( ::GetFileSizeEx( file_handle, &file_size ) || ( file_handle == handle_traits::invalid_value ) );
+    LARGE_INTEGER file_size{ .QuadPart = 0 }; // simplify user code: return zero for closed/default constructed handles
+    BOOST_VERIFY( ::GetFileSizeEx( file_handle.value, &file_size ) || ( file_handle == handle_traits::invalid_value ) );
     return file_size.QuadPart;
 }
 

--- a/src/mapping/mapping.win32.cpp
+++ b/src/mapping/mapping.win32.cpp
@@ -28,13 +28,14 @@ namespace psi::vm
 inline namespace win32
 {
 //------------------------------------------------------------------------------
-
+[[ gnu::cold, gnu::noinline ]]
 std::uint64_t get_size( mapping::const_handle const mapping_handle ) noexcept
 {
     using namespace nt;
     SECTION_BASIC_INFORMATION info;
+    info.SectionSize.QuadPart = 0; // simplify user code: return zero for closed/default constructed handles
     auto const result{ NtQuerySection( mapping_handle.value, SECTION_INFORMATION_CLASS::SectionBasicInformation, &info, sizeof( info ), nullptr ) };
-    BOOST_ASSUME( result == STATUS_SUCCESS );
+    BOOST_ASSUME( result == STATUS_SUCCESS || !mapping_handle );
     return info.SectionSize.QuadPart;
 }
 


### PR DESCRIPTION
… - very minimal overhead for simplifying calling code.

mapping::underlying_file(): changed to no longer require an actually file-backed mapping (i.e. allow simply fetching the file handle - it will be an invalid handle if not file backed). Windows: fixed get_size to take a file_handle const_reference. Minor stylistic changes and cleanups.