### PR TITLE
Full `std::flat_map` (P0429R9) polyfill (for MSVC effectively)

### DIFF
--- a/include/psi/vm/containers/abi.hpp
+++ b/include/psi/vm/containers/abi.hpp
@@ -106,6 +106,23 @@ template <typename T> bool constexpr reg<pass_rv_in_reg<T>>{ true };
 template <typename T>
 concept Reg = reg<T>;
 
+// utility for passing non trivial predicates to algorithms which pass them around by-val
+template <typename Pred>
+decltype( auto ) make_trivially_copyable_predicate( Pred && __restrict pred ) noexcept {
+    if constexpr ( can_be_passed_in_reg<std::remove_cvref<Pred>> ) {
+        return std::forward<Pred>( pred );
+    } else {
+        return [&pred]( auto const & ... args ) noexcept( noexcept( pred( args... ) ) ) {
+            return pred( args... );
+        };
+    }
+} // make_trivially_copyable_predicate
+
+namespace detail
+{
+    [[ noreturn, gnu::cold ]] void throw_out_of_range( char const * msg );
+} // namespace detail
+
 PSI_WARNING_DISABLE_POP()
 
 //------------------------------------------------------------------------------

--- a/include/psi/vm/containers/b+tree.hpp
+++ b/include/psi/vm/containers/b+tree.hpp
@@ -95,19 +95,6 @@ struct [[ clang::trivial_abi]] unique_nonowned_ptr {
 }; // class unique_nonowned_ptr
 
 
-// utility for passing non trivial predicates to algorithms which pass them around by-val
-template <typename Pred>
-decltype( auto ) make_trivially_copyable_predicate( Pred && __restrict pred ) noexcept {
-    if constexpr ( can_be_passed_in_reg<std::remove_cvref<Pred>> ) {
-        return std::forward<Pred>( pred );
-    } else {
-        return [&pred]( auto const & ... args ) noexcept( noexcept( pred( args... ) ) ) {
-            return pred( args... );
-        };
-    }
-} // make_trivially_copyable_predicate
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // \class bptree_base
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/psi/vm/containers/fc_vector.hpp
+++ b/include/psi/vm/containers/fc_vector.hpp
@@ -57,7 +57,7 @@ struct assert_on_overflow {
     }
 }; // assert_on_overflow
 struct throw_on_overflow {
-    [[ noreturn ]] static void operator()() { detail::throw_out_of_range(); }
+    [[ noreturn ]] static void operator()() { detail::throw_out_of_range( "psi::vm::fc_vector overflow" ); }
 }; // throw_on_overflow
 
 

--- a/include/psi/vm/containers/flat_map.hpp
+++ b/include/psi/vm/containers/flat_map.hpp
@@ -1,0 +1,880 @@
+////////////////////////////////////////////////////////////////////////////////
+/// std::flat_map polyfill for platforms lacking <flat_map> (notably MSVC STL)
+///
+/// Implements the C++23 std::flat_map interface (P0429R9) with separate key
+/// and value containers for cache-friendly key-only iteration.
+///
+/// Architecture:
+///   flat_map privately inherits detail::paired_storage<KC, MC>, a comparator-
+///   agnostic base that synchronises dual-container operations (insert, erase,
+///   append, clear, reserve, replace, ...). The base class doubles as the
+///   standard-required `containers` type returned by extract().
+///
+/// Extensions beyond C++23 std::flat_map:
+///   - reserve(n), shrink_to_fit()        — bulk pre-allocation / compaction
+///   - merge(source) (lvalue & rvalue)    — std::map-style element transfer
+///   - insert_range(sorted_unique_t, R&&) — sorted bulk range insert
+///
+/// Differences from the standard interface:
+///   - Uses psi::vm::sorted_unique_t instead of std::sorted_unique_t
+///   - containers type = paired_storage base (aggregate with .keys / .values),
+///     not a separate nested struct
+///   - extract() returns by move-constructing the base (conditionally noexcept)
+///   - replace() is conditionally noexcept (move-assignable containers)
+///
+/// Copyright (c) Domagoj Saric.
+///
+/// Use, modification and distribution is subject to the
+/// Boost Software License, Version 1.0.
+/// (See accompanying file LICENSE_1_0.txt or copy at
+/// http://www.boost.org/LICENSE_1_0.txt)
+///
+/// For more information, see http://www.boost.org
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#pragma once
+
+#include "abi.hpp"
+
+#include <boost/assert.hpp>
+
+#include <algorithm>
+#include <compare>
+#include <concepts>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <ranges>
+#include <type_traits>
+#include <utility>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace psi::vm
+{
+//------------------------------------------------------------------------------
+
+//==============================================================================
+// detail::paired_storage — comparator-agnostic synchronized dual-container ops
+// Serves as the flat_map/flat_set divergence point (flat_set uses a simpler
+// single-container equivalent).
+//==============================================================================
+namespace detail {
+
+template <typename KeyContainer, typename MappedContainer>
+struct paired_storage
+{
+    using size_type = std::conditional_t
+    <
+        ( sizeof( typename KeyContainer::size_type ) <= sizeof( typename MappedContainer::size_type ) ),
+        typename KeyContainer   ::size_type,
+        typename MappedContainer::size_type
+    >;
+    using difference_type = std::ptrdiff_t;
+
+    KeyContainer    keys;
+    MappedContainer values;
+
+    //--------------------------------------------------------------------------
+    // Zip view for synchronized sort/merge/unique
+    //--------------------------------------------------------------------------
+    auto zip_view() noexcept { return std::views::zip( keys, values ); }
+
+    //--------------------------------------------------------------------------
+    // Truncate both containers to newSize (shrink-only, noexcept)
+    //--------------------------------------------------------------------------
+    void truncate_to( size_type const newSize ) noexcept
+    {
+        if constexpr ( requires { keys.shrink_to( newSize ); } )
+            keys.shrink_to( newSize );
+        else
+            keys.resize( newSize );
+        if constexpr ( requires { values.shrink_to( newSize ); } )
+            values.shrink_to( newSize );
+        else
+            values.resize( newSize );
+    }
+
+    //--------------------------------------------------------------------------
+    // Synchronized single-element insert at position (exception-safe)
+    //--------------------------------------------------------------------------
+    template <typename K, typename V>
+    void insert_element_at( size_type const pos, K && key, V && val ) {
+        auto const p{ static_cast<difference_type>( pos ) };
+        keys.insert( keys.begin() + p, std::forward<K>( key ) );
+        try {
+            values.insert( values.begin() + p, std::forward<V>( val ) );
+        } catch ( ... ) {
+            keys.erase( keys.begin() + p );
+            throw;
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Synchronized erase
+    //--------------------------------------------------------------------------
+    void erase_element_at( size_type const pos ) noexcept {
+        auto const p{ static_cast<difference_type>( pos ) };
+        keys  .erase( keys  .begin() + p );
+        values.erase( values.begin() + p );
+    }
+
+    void erase_elements( size_type const first, size_type const last ) noexcept {
+        auto const f{ static_cast<difference_type>( first ) };
+        auto const l{ static_cast<difference_type>( last  ) };
+        keys  .erase( keys  .begin() + f, keys  .begin() + l );
+        values.erase( values.begin() + f, values.begin() + l );
+    }
+
+    //--------------------------------------------------------------------------
+    // Bulk append from separate key/value ranges (exception-safe)
+    //--------------------------------------------------------------------------
+    template <typename KR, typename VR>
+    void append_ranges( KR && key_rg, VR && val_rg ) {
+        auto const oldSize{ keys.size() };
+        keys.append_range( std::forward<KR>( key_rg ) );
+        try {
+            values.append_range( std::forward<VR>( val_rg ) );
+        } catch ( ... ) {
+            truncate_to( oldSize );
+            throw;
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Bulk append from pair iterator range
+    //--------------------------------------------------------------------------
+    template <typename InputIt>
+    void append_from( InputIt const first, InputIt const last ) {
+        auto rg{ std::ranges::subrange( first, last ) };
+        append_ranges( rg | std::views::keys, rg | std::views::values );
+    }
+
+    //--------------------------------------------------------------------------
+    // Move-append from raw container pair (for rvalue merge)
+    //--------------------------------------------------------------------------
+    void append_move_containers( KeyContainer & src_keys, MappedContainer & src_values ) {
+        append_ranges
+        (
+            src_keys   | std::views::as_rvalue,
+            src_values | std::views::as_rvalue
+        );
+    }
+
+    //--------------------------------------------------------------------------
+    // Reserve / Shrink
+    //--------------------------------------------------------------------------
+    void reserve( size_type const n ) {
+        keys  .reserve( n );
+        values.reserve( n );
+    }
+
+    void shrink_to_fit() noexcept {
+        keys  .shrink_to_fit();
+        values.shrink_to_fit();
+    }
+
+    //--------------------------------------------------------------------------
+    // Replace (move-assign both containers)
+    //--------------------------------------------------------------------------
+    void replace( KeyContainer new_keys, MappedContainer new_values )
+        noexcept( std::is_nothrow_move_assignable_v<KeyContainer> && std::is_nothrow_move_assignable_v<MappedContainer> )
+    {
+        BOOST_ASSERT( new_keys.size() == new_values.size() );
+        keys   = std::move( new_keys   );
+        values = std::move( new_values );
+    }
+
+    //--------------------------------------------------------------------------
+    // Clear / Swap
+    //--------------------------------------------------------------------------
+    void clear() noexcept {
+        keys  .clear();
+        values.clear();
+    }
+
+    void swap_storage( paired_storage & other ) noexcept {
+        using std::swap;
+        swap( keys,   other.keys   );
+        swap( values, other.values );
+    }
+}; // struct paired_storage
+
+} // namespace detail
+
+
+struct sorted_unique_t { explicit sorted_unique_t() = default; };
+inline constexpr sorted_unique_t sorted_unique{};
+
+//==============================================================================
+// flat_map — sorted associative container with separate key/value storage
+//==============================================================================
+
+template
+<
+    typename Key,
+    typename T,
+    typename Compare         = std::less<Key>,
+    typename KeyContainer    = std::vector<Key>,
+    typename MappedContainer = std::vector<T>
+>
+class flat_map
+    : private detail::paired_storage<KeyContainer, MappedContainer>
+{
+    using base = detail::paired_storage<KeyContainer, MappedContainer>;
+
+    static_assert( std::is_same_v<Key, typename KeyContainer   ::value_type>, "KeyContainer::value_type must be Key" );
+    static_assert( std::is_same_v<T,   typename MappedContainer::value_type>, "MappedContainer::value_type must be T" );
+
+public:
+    //--------------------------------------------------------------------------
+    // Member types
+    //--------------------------------------------------------------------------
+    using key_type              = Key;
+    using mapped_type           = T;
+    using value_type            = std::pair<key_type, mapped_type>;
+    using key_compare           = Compare;
+    using reference             = std::pair<key_type const &, mapped_type       &>;
+    using const_reference       = std::pair<key_type const &, mapped_type const &>;
+    using size_type             = typename base::size_type;
+    using difference_type       = typename base::difference_type;
+    using key_container_type    = KeyContainer;
+    using mapped_container_type = MappedContainer;
+    using containers            = base;
+
+    //--------------------------------------------------------------------------
+    // value_compare
+    //--------------------------------------------------------------------------
+    class value_compare : private key_compare {
+        friend flat_map;
+        value_compare( key_compare c ) noexcept( std::is_nothrow_move_constructible_v<key_compare> ) : key_compare{ std::move( c ) } {}
+    public:
+        bool operator()( const_reference a, const_reference b ) const noexcept { return key_compare::operator()( a.first, b.first ); }
+    };
+
+    //--------------------------------------------------------------------------
+    // Iterator
+    //--------------------------------------------------------------------------
+private:
+    template <bool IsConst>
+    class iterator_impl
+    {
+    public:
+        using iterator_concept  = std::random_access_iterator_tag;
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type        = flat_map::value_type;
+        using difference_type   = flat_map::difference_type;
+        using reference         = std::conditional_t<IsConst, flat_map::const_reference, flat_map::reference>;
+
+        struct arrow_proxy {
+            reference ref;
+            constexpr reference       * operator->()       noexcept { return &ref; }
+            constexpr reference const * operator->() const noexcept { return &ref; }
+        };
+        using pointer = arrow_proxy;
+
+    private:
+        friend flat_map;
+        friend iterator_impl<!IsConst>;
+
+        using map_ptr = std::conditional_t<IsConst, flat_map const *, flat_map *>;
+
+        map_ptr         map_{ nullptr };
+        difference_type idx_{ 0 };
+
+        constexpr iterator_impl( map_ptr const m, difference_type const i ) noexcept : map_{ m }, idx_{ i } {}
+
+    public:
+        constexpr iterator_impl() noexcept = default;
+        constexpr iterator_impl( iterator_impl const & ) noexcept = default;
+        constexpr iterator_impl & operator=( iterator_impl const & ) noexcept = default;
+
+        constexpr iterator_impl( iterator_impl<!IsConst> const & other ) noexcept requires IsConst
+            : map_{ other.map_ }, idx_{ other.idx_ } {}
+
+        constexpr reference operator*() const noexcept {
+            return { map_->base::keys[ static_cast<size_type>( idx_ ) ], map_->base::values[ static_cast<size_type>( idx_ ) ] };
+        }
+
+        constexpr arrow_proxy operator->() const noexcept { return { **this }; }
+
+        constexpr reference operator[]( difference_type const n ) const noexcept {
+            return *( *this + n );
+        }
+
+        constexpr iterator_impl & operator++(     )    noexcept { ++idx_; return *this; }
+        constexpr iterator_impl   operator++( int ) noexcept { auto tmp{ *this }; ++idx_; return tmp; }
+        constexpr iterator_impl & operator--(     )    noexcept { --idx_; return *this; }
+        constexpr iterator_impl   operator--( int ) noexcept { auto tmp{ *this }; --idx_; return tmp; }
+
+        constexpr iterator_impl & operator+=( difference_type const n ) noexcept { idx_ += n; return *this; }
+        constexpr iterator_impl & operator-=( difference_type const n ) noexcept { idx_ -= n; return *this; }
+
+        friend constexpr iterator_impl operator+( iterator_impl it, difference_type const n ) noexcept { return { it.map_, it.idx_ + n }; }
+        friend constexpr iterator_impl operator+( difference_type const n, iterator_impl it ) noexcept { return { it.map_, it.idx_ + n }; }
+        friend constexpr iterator_impl operator-( iterator_impl it, difference_type const n ) noexcept { return { it.map_, it.idx_ - n }; }
+
+        friend constexpr difference_type operator-( iterator_impl const & a, iterator_impl const & b ) noexcept { return a.idx_ - b.idx_; }
+
+        friend constexpr bool operator==( iterator_impl const & a, iterator_impl const & b ) noexcept { return a.idx_ == b.idx_; }
+        friend constexpr auto operator<=>( iterator_impl const & a, iterator_impl const & b ) noexcept { return a.idx_ <=> b.idx_; }
+    }; // iterator_impl
+
+public:
+    using iterator               = iterator_impl<false>;
+    using const_iterator         = iterator_impl<true>;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    //--------------------------------------------------------------------------
+    // Constructors
+    //--------------------------------------------------------------------------
+
+    static auto constexpr nothrow_move_constructible
+    {
+        std::is_nothrow_move_constructible_v<KeyContainer   > &&
+        std::is_nothrow_move_constructible_v<MappedContainer> &&
+        std::is_nothrow_copy_constructible_v<Compare        >
+    };
+
+    flat_map() = default;
+
+    explicit flat_map( Compare const & comp ) noexcept( std::is_nothrow_copy_constructible_v<Compare> )
+        : comp_{ comp } {}
+
+    flat_map( KeyContainer keys, MappedContainer values, Compare const & comp = Compare{} ) noexcept( nothrow_move_constructible )
+        : base{ std::move( keys ), std::move( values ) }, comp_{ comp }
+    {
+        BOOST_ASSERT( base::keys.size() == base::values.size() );
+        sort_and_unique();
+    }
+
+    flat_map( sorted_unique_t, KeyContainer keys, MappedContainer values, Compare const & comp = Compare{} ) noexcept( nothrow_move_constructible )
+        : base{ std::move( keys ), std::move( values ) }, comp_{ comp }
+    {
+        BOOST_ASSERT( base::keys.size() == base::values.size() );
+    }
+
+    template <std::input_iterator InputIt>
+    flat_map( InputIt first, InputIt const last, Compare const & comp = Compare{} )
+        : comp_{ comp }
+    {
+        base::append_from( first, last );
+        sort_and_unique();
+    }
+
+    template <std::input_iterator InputIt>
+    flat_map( sorted_unique_t, InputIt first, InputIt const last, Compare const & comp = Compare{} )
+        : comp_{ comp }
+    {
+        base::append_from( first, last );
+    }
+
+    template <std::ranges::input_range R>
+    flat_map( std::from_range_t, R && rg, Compare const & comp = Compare{} )
+        : comp_{ comp }
+    {
+        insert_range( std::forward<R>( rg ) );
+    }
+
+    flat_map( std::initializer_list<value_type> const il, Compare const & comp = Compare{} )
+        : flat_map( il.begin(), il.end(), comp ) {}
+
+    flat_map( sorted_unique_t, std::initializer_list<value_type> il, Compare const & comp = Compare{} )
+        : flat_map( sorted_unique, il.begin(), il.end(), comp ) {}
+
+    flat_map( flat_map const & ) = default;
+    flat_map( flat_map && )      = default;
+
+    flat_map & operator=( flat_map const & ) = default;
+    flat_map & operator=( flat_map && )      = default;
+
+    flat_map & operator=( std::initializer_list<value_type> il ) {
+        clear();
+        insert( il );
+        return *this;
+    }
+
+    //--------------------------------------------------------------------------
+    // Iterators
+    //--------------------------------------------------------------------------
+    iterator       begin()       noexcept { return { this, 0 }; }
+    const_iterator begin() const noexcept { return { this, 0 }; }
+    iterator       end  ()       noexcept { return { this, static_cast<difference_type>( base::keys.size() ) }; }
+    const_iterator end  () const noexcept { return { this, static_cast<difference_type>( base::keys.size() ) }; }
+
+    const_iterator cbegin() const noexcept { return begin(); }
+    const_iterator cend  () const noexcept { return end  (); }
+
+    reverse_iterator       rbegin()       noexcept { return reverse_iterator      { end  () }; }
+    const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator{ end  () }; }
+    reverse_iterator       rend  ()       noexcept { return reverse_iterator      { begin() }; }
+    const_reverse_iterator rend  () const noexcept { return const_reverse_iterator{ begin() }; }
+
+    const_reverse_iterator crbegin() const noexcept { return rbegin(); }
+    const_reverse_iterator crend  () const noexcept { return rend  (); }
+
+    //--------------------------------------------------------------------------
+    // Capacity
+    //--------------------------------------------------------------------------
+    [[nodiscard]] bool      empty   () const noexcept { return base::keys.empty(); }
+    [[nodiscard]] size_type size    () const noexcept { return static_cast<size_type>( base::keys.size() ); }
+    [[nodiscard]] size_type max_size() const noexcept { return std::min( base::keys.max_size(), base::values.max_size() ); }
+
+    //--------------------------------------------------------------------------
+    // Element access
+    //--------------------------------------------------------------------------
+    mapped_type & operator[]( key_type const & key ) {
+        return try_emplace( key ).first->second;
+    }
+
+    mapped_type & operator[]( key_type && key ) {
+        return try_emplace( std::move( key ) ).first->second;
+    }
+
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    mapped_type & operator[]( K && key ) {
+        return try_emplace( std::forward<K>( key ) ).first->second;
+    }
+
+    mapped_type       & at( key_type const & key )       { auto const it{ find( key ) }; if ( it == end() ) detail::throw_out_of_range( "psi::vm::flat_map::at" ); return it->second; }
+    mapped_type const & at( key_type const & key ) const { auto const it{ find( key ) }; if ( it == end() ) detail::throw_out_of_range( "psi::vm::flat_map::at" ); return it->second; }
+
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    mapped_type       & at( K const & key )       { auto const it{ find( key ) }; if ( it == end() ) detail::throw_out_of_range( "psi::vm::flat_map::at" ); return it->second; }
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    mapped_type const & at( K const & key ) const { auto const it{ find( key ) }; if ( it == end() ) detail::throw_out_of_range( "psi::vm::flat_map::at" ); return it->second; }
+
+    //--------------------------------------------------------------------------
+    // Lookup
+    //--------------------------------------------------------------------------
+private:
+    template <typename K>
+    [[nodiscard]] size_type lower_bound_index( K const & key ) const noexcept {
+        auto const comp{ make_trivially_copyable_predicate( comp_ ) };
+        return static_cast<size_type>( std::lower_bound( base::keys.begin(), base::keys.end(), key, comp ) - base::keys.begin() );
+    }
+    template <typename K>
+    [[nodiscard]] size_type upper_bound_index( K const & key ) const noexcept {
+        auto const comp{ make_trivially_copyable_predicate( comp_ ) };
+        return static_cast<size_type>( std::upper_bound( base::keys.begin(), base::keys.end(), key, comp ) - base::keys.begin() );
+    }
+    template <typename K>
+    [[nodiscard]] bool key_eq_at( size_type const pos, K const & key ) const noexcept {
+        return pos < base::keys.size() && !comp_( key, base::keys[ pos ] );
+    }
+
+public:
+    iterator       find( key_type const & key )       noexcept { auto const pos{ lower_bound_index( key ) }; return key_eq_at( pos, key ) ? iterator      { this, static_cast<difference_type>( pos ) } : end(); }
+    const_iterator find( key_type const & key ) const noexcept { auto const pos{ lower_bound_index( key ) }; return key_eq_at( pos, key ) ? const_iterator{ this, static_cast<difference_type>( pos ) } : end(); }
+
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    iterator       find( K const & key )       noexcept { auto const pos{ lower_bound_index( key ) }; return key_eq_at( pos, key ) ? iterator      { this, static_cast<difference_type>( pos ) } : end(); }
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    const_iterator find( K const & key ) const noexcept { auto const pos{ lower_bound_index( key ) }; return key_eq_at( pos, key ) ? const_iterator{ this, static_cast<difference_type>( pos ) } : end(); }
+
+    [[nodiscard]] size_type count   ( key_type const & key ) const noexcept { return find( key ) != end() ? 1 : 0; }
+    [[nodiscard]] bool      contains( key_type const & key ) const noexcept { return find( key ) != end(); }
+
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    [[nodiscard]] size_type count   ( K const & key ) const noexcept { return find( key ) != end() ? 1 : 0; }
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    [[nodiscard]] bool      contains( K const & key ) const noexcept { return find( key ) != end(); }
+
+    iterator       lower_bound( key_type const & key )       noexcept { return { this, static_cast<difference_type>( lower_bound_index( key ) ) }; }
+    const_iterator lower_bound( key_type const & key ) const noexcept { return { this, static_cast<difference_type>( lower_bound_index( key ) ) }; }
+    iterator       upper_bound( key_type const & key )       noexcept { return { this, static_cast<difference_type>( upper_bound_index( key ) ) }; }
+    const_iterator upper_bound( key_type const & key ) const noexcept { return { this, static_cast<difference_type>( upper_bound_index( key ) ) }; }
+
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    iterator       lower_bound( K const & key )       noexcept { return { this, static_cast<difference_type>( lower_bound_index( key ) ) }; }
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    const_iterator lower_bound( K const & key ) const noexcept { return { this, static_cast<difference_type>( lower_bound_index( key ) ) }; }
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    iterator       upper_bound( K const & key )       noexcept { return { this, static_cast<difference_type>( upper_bound_index( key ) ) }; }
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    const_iterator upper_bound( K const & key ) const noexcept { return { this, static_cast<difference_type>( upper_bound_index( key ) ) }; }
+
+    std::pair<iterator, iterator>             equal_range( key_type const & key )       noexcept { return { lower_bound( key ), upper_bound( key ) }; }
+    std::pair<const_iterator, const_iterator> equal_range( key_type const & key ) const noexcept { return { lower_bound( key ), upper_bound( key ) }; }
+
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    std::pair<iterator, iterator>             equal_range( K const & key )       noexcept { return { lower_bound( key ), upper_bound( key ) }; }
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    std::pair<const_iterator, const_iterator> equal_range( K const & key ) const noexcept { return { lower_bound( key ), upper_bound( key ) }; }
+
+    //--------------------------------------------------------------------------
+    // Modifiers
+    //--------------------------------------------------------------------------
+    std::pair<iterator, bool> insert( value_type const & v ) {
+        return emplace( v.first, v.second );
+    }
+
+    std::pair<iterator, bool> insert( value_type && v ) {
+        return emplace( std::move( v.first ), std::move( v.second ) );
+    }
+
+    iterator insert( const_iterator hint, value_type const & v ) {
+        return emplace_hint( hint, v.first, v.second );
+    }
+
+    iterator insert( const_iterator hint, value_type && v ) {
+        return emplace_hint( hint, std::move( v.first ), std::move( v.second ) );
+    }
+
+    // Bulk insert — append + sort + merge + deduplicate
+    template <std::input_iterator InputIt>
+    void insert( InputIt first, InputIt last ) {
+        auto const oldSize{ size() };
+        base::append_from( first, last );
+        sort_merge_unique<false>( oldSize );
+    }
+
+    void insert( std::initializer_list<value_type> il ) {
+        insert( il.begin(), il.end() );
+    }
+
+    // Sorted unique bulk insert — append + merge + deduplicate (no sort)
+    template <std::input_iterator InputIt>
+    void insert( sorted_unique_t, InputIt first, InputIt last ) {
+        auto const oldSize{ size() };
+        base::append_from( first, last );
+        sort_merge_unique<true>( oldSize );
+    }
+
+    void insert( sorted_unique_t, std::initializer_list<value_type> il ) {
+        insert( sorted_unique, il.begin(), il.end() );
+    }
+
+    // insert_range — delegates to iterator pair insert via views::common
+    template <std::ranges::input_range R>
+    requires std::convertible_to<std::ranges::range_reference_t<R>, value_type>
+    void insert_range( R && rg ) {
+        if constexpr ( std::ranges::sized_range<R> )
+            reserve( size() + static_cast<size_type>( std::ranges::size( rg ) ) );
+        auto common{ std::forward<R>( rg ) | std::views::common };
+        insert( std::ranges::begin( common ), std::ranges::end( common ) );
+    }
+
+    template <std::ranges::input_range R>
+    requires std::convertible_to<std::ranges::range_reference_t<R>, value_type>
+    void insert_range( sorted_unique_t, R && rg ) {
+        if constexpr ( std::ranges::sized_range<R> )
+            reserve( size() + static_cast<size_type>( std::ranges::size( rg ) ) );
+        auto common{ std::forward<R>( rg ) | std::views::common };
+        insert( sorted_unique, std::ranges::begin( common ), std::ranges::end( common ) );
+    }
+
+    template <typename K, typename... Args>
+    std::pair<iterator, bool> try_emplace( K && key, Args &&... args ) {
+        auto const pos{ lower_bound_index( key ) };
+        if ( key_eq_at( pos, key ) )
+            return { iterator{ this, static_cast<difference_type>( pos ) }, false };
+        base::insert_element_at( pos, key_type( std::forward<K>( key ) ), mapped_type( std::forward<Args>( args )... ) );
+        return { iterator{ this, static_cast<difference_type>( pos ) }, true };
+    }
+
+    template <typename K, typename... Args>
+    iterator try_emplace( const_iterator hint, K && key, Args &&... args ) {
+        auto const hintIdx{ static_cast<size_type>( hint.idx_ ) };
+        bool const hintValid{
+            ( hintIdx == 0      || comp_( base::keys[ hintIdx - 1 ], key ) ) &&
+            ( hintIdx >= size() || comp_( key, base::keys[ hintIdx ] ) )
+        };
+        if ( hintValid ) {
+            base::insert_element_at( hintIdx, key_type( std::forward<K>( key ) ), mapped_type( std::forward<Args>( args )... ) );
+            return { this, static_cast<difference_type>( hintIdx ) };
+        }
+        if ( hintIdx < size() && !comp_( key, base::keys[ hintIdx ] ) && !comp_( base::keys[ hintIdx ], key ) )
+            return { this, static_cast<difference_type>( hintIdx ) };
+        return try_emplace( std::forward<K>( key ), std::forward<Args>( args )... ).first;
+    }
+
+    template <typename K, typename M>
+    std::pair<iterator, bool> insert_or_assign( K && key, M && value ) {
+        auto const pos{ lower_bound_index( key ) };
+        if ( key_eq_at( pos, key ) ) {
+            base::values[ pos ] = std::forward<M>( value );
+            return { iterator{ this, static_cast<difference_type>( pos ) }, false };
+        }
+        base::insert_element_at( pos, key_type( std::forward<K>( key ) ), std::forward<M>( value ) );
+        return { iterator{ this, static_cast<difference_type>( pos ) }, true };
+    }
+
+    template <typename K, typename M>
+    iterator insert_or_assign( const_iterator hint, K && key, M && value ) {
+        auto const hintIdx{ static_cast<size_type>( hint.idx_ ) };
+        if ( hintIdx < size() && !comp_( key, base::keys[ hintIdx ] ) && !comp_( base::keys[ hintIdx ], key ) ) {
+            base::values[ hintIdx ] = std::forward<M>( value );
+            return { this, hint.idx_ };
+        }
+        return insert_or_assign( std::forward<K>( key ), std::forward<M>( value ) ).first;
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace( Args &&... args ) {
+        value_type v( std::forward<Args>( args )... );
+        return try_emplace( std::move( v.first ), std::move( v.second ) );
+    }
+
+    iterator emplace_hint( const_iterator hint, auto &&... args ) {
+        value_type v( std::forward<decltype( args )>( args )... );
+        return try_emplace( hint, std::move( v.first ), std::move( v.second ) );
+    }
+
+    iterator erase( iterator pos ) noexcept { return erase( const_iterator{ pos } ); }
+
+    iterator erase( const_iterator pos ) noexcept {
+        auto const idx{ static_cast<size_type>( pos.idx_ ) };
+        base::erase_element_at( idx );
+        return { this, static_cast<difference_type>( idx ) };
+    }
+
+    iterator erase( const_iterator first, const_iterator last ) noexcept {
+        auto const firstIdx{ static_cast<size_type>( first.idx_ ) };
+        auto const lastIdx { static_cast<size_type>( last .idx_ ) };
+        base::erase_elements( firstIdx, lastIdx );
+        return { this, first.idx_ };
+    }
+
+    size_type erase( key_type const & key ) noexcept {
+        auto const it{ find( key ) };
+        if ( it == end() ) return 0;
+        erase( const_iterator{ it } );
+        return 1;
+    }
+
+    template <typename K> requires( requires{ typename Compare::is_transparent; } )
+    size_type erase( K const & key ) noexcept {
+        auto const it{ find( key ) };
+        if ( it == end() ) return 0;
+        erase( const_iterator{ it } );
+        return 1;
+    }
+
+    using base::clear;
+
+    void swap( flat_map & other ) noexcept {
+        base::swap_storage( other );
+        using std::swap;
+        swap( comp_, other.comp_ );
+    }
+
+    friend void swap( flat_map & a, flat_map & b ) noexcept { a.swap( b ); }
+
+    //--------------------------------------------------------------------------
+    // Extraction & replacement
+    //--------------------------------------------------------------------------
+    containers extract() noexcept( std::is_nothrow_move_constructible_v<base> ) { return std::move( static_cast<base &>( *this ) ); }
+
+    using base::replace;
+
+    //--------------------------------------------------------------------------
+    // Observers
+    //--------------------------------------------------------------------------
+    [[nodiscard]] key_compare   key_comp  () const noexcept { return comp_; }
+    [[nodiscard]] value_compare value_comp() const noexcept { return value_compare{ comp_ }; }
+
+    [[nodiscard]] key_container_type    const & keys  () const noexcept { return base::keys;   }
+    [[nodiscard]] mapped_container_type const & values() const noexcept { return base::values; }
+
+    //--------------------------------------------------------------------------
+    // Merge (extension — not in std::flat_map, matches std::map::merge semantics)
+    //--------------------------------------------------------------------------
+    void merge( flat_map & source ) {
+        if ( source.empty() || this == &source )
+            return;
+        // O(N+M) sorted scan to find source indices to transfer
+        std::vector<size_type> transferIndices;
+        transferIndices.reserve( source.size() );
+        {
+            size_type si{ 0 };
+            size_type ti{ 0 };
+            auto const sn{ source.size() };
+            auto const tn{ size() };
+            while ( si < sn && ti < tn ) {
+                if ( comp_( source.base::keys[ si ], base::keys[ ti ] ) ) {
+                    transferIndices.push_back( si );
+                    ++si;
+                } else if ( comp_( base::keys[ ti ], source.base::keys[ si ] ) ) {
+                    ++ti;
+                } else {
+                    ++si;
+                    ++ti;
+                }
+            }
+            for ( ; si < sn; ++si )
+                transferIndices.push_back( si );
+        }
+        if ( transferIndices.empty() )
+            return;
+
+        // Append only non-duplicate elements (already in sorted order)
+        auto const oldSize{ size() };
+        for ( auto const idx : transferIndices ) {
+            base::keys  .emplace_back( std::move( source.base::keys  [ idx ] ) );
+            base::values.emplace_back( std::move( source.base::values[ idx ] ) );
+        }
+        sort_merge_unique<true>( oldSize );
+        // Compact source: remove transferred elements in O(M) single pass
+        {
+            size_type dst{ 0 };
+            size_type nextT{ 0 };
+            for ( size_type src{ 0 }, n{ source.size() }; src < n; ++src ) {
+                if ( nextT < transferIndices.size() && src == transferIndices[ nextT ] ) {
+                    ++nextT;
+                } else {
+                    if ( dst != src ) {
+                        source.base::keys  [ dst ] = std::move( source.base::keys  [ src ] );
+                        source.base::values[ dst ] = std::move( source.base::values[ src ] );
+                    }
+                    ++dst;
+                }
+            }
+            source.truncate_to( dst );
+        }
+    }
+
+    void merge( flat_map && source ) {
+        auto const oldSize{ size() };
+        base::append_move_containers( source.base::keys, source.base::values );
+        sort_merge_unique<true>( oldSize );
+        source.clear();
+    }
+
+    //--------------------------------------------------------------------------
+    // Comparison
+    //--------------------------------------------------------------------------
+    friend bool operator==( flat_map const & a, flat_map const & b ) {
+        return a.keys() == b.keys() && a.values() == b.values();
+    }
+
+    friend auto operator<=>( flat_map const & a, flat_map const & b )
+    requires std::three_way_comparable<Key> && std::three_way_comparable<T>
+    {
+        if ( auto const cmp{ std::lexicographical_compare_three_way( a.keys().begin(), a.keys().end(), b.keys().begin(), b.keys().end() ) }; cmp != 0 )
+            return cmp;
+        return std::lexicographical_compare_three_way( a.values().begin(), a.values().end(), b.values().begin(), b.values().end() );
+    }
+
+    //--------------------------------------------------------------------------
+    // erase_if (friend non-member)
+    //--------------------------------------------------------------------------
+    template <typename Pred>
+    friend size_type erase_if( flat_map & c, Pred pred ) {
+        auto zv{ c.zip_view() };
+        auto const it{ std::remove_if( zv.begin(), zv.end(), [&pred]( auto && zipped ) {
+            return pred( const_reference{ std::get<0>( zipped ), std::get<1>( zipped ) } );
+        } ) };
+        auto const newSize{ static_cast<size_type>( it - zv.begin() ) };
+        auto const erased { static_cast<size_type>( zv.end() - it ) };
+        c.truncate_to( newSize );
+        return erased;
+    }
+
+    //--------------------------------------------------------------------------
+    // Reserve (extension — not in std but useful)
+    //--------------------------------------------------------------------------
+    using base::reserve;
+    using base::shrink_to_fit;
+
+    //--------------------------------------------------------------------------
+    // Private helpers
+    //--------------------------------------------------------------------------
+private:
+    // Sort entire map and remove duplicates (first occurrence kept)
+    void sort_and_unique() {
+        auto zv{ base::zip_view() };
+        std::ranges::sort( zv, comp_, key_proj() );
+        auto const dupStart{ std::ranges::unique( zv, key_equiv(), key_proj() ).begin() };
+        base::truncate_to( static_cast<size_type>( dupStart - zv.begin() ) );
+    }
+
+    // Bulk insert: sort new tail, inplace_merge with existing, deduplicate
+    template <bool WasSorted>
+    void sort_merge_unique( size_type const oldSize ) {
+        if ( static_cast<size_type>( base::keys.size() ) <= oldSize )
+            return;
+
+        auto zv{ base::zip_view() };
+        auto const appendStart{ zv.begin() + static_cast<difference_type>( oldSize ) };
+
+        if constexpr ( !WasSorted )
+            std::ranges::sort( appendStart, zv.end(), comp_, key_proj() );
+
+        if ( oldSize > 0 )
+            std::ranges::inplace_merge( zv.begin(), appendStart, zv.end(), comp_, key_proj() );
+
+        auto const dupStart{ std::ranges::unique( zv, key_equiv(), key_proj() ).begin() };
+        base::truncate_to( static_cast<size_type>( dupStart - zv.begin() ) );
+    }
+
+    // Key projection for ranges algorithms (sort, inplace_merge, unique)
+    // key_proj() is a range adaptor, not a per-element callable — need a custom functor
+    static constexpr auto key_proj() noexcept {
+        return []<typename E>( E && e ) -> decltype(auto) {
+            return std::get<0>( std::forward<E>( e ) );
+        };
+    }
+
+    // Key equivalence predicate for ranges::unique (receives projected keys)
+    auto key_equiv() const noexcept {
+        return [this]( auto const & a, auto const & b ) {
+            return !comp_( a, b ) && !comp_( b, a );
+        };
+    }
+
+    //--------------------------------------------------------------------------
+    // Data members
+    //--------------------------------------------------------------------------
+#ifdef _MSC_VER
+    [[ msvc::no_unique_address ]]
+#else
+    [[ no_unique_address ]]
+#endif
+    key_compare comp_;
+}; // class flat_map
+
+//------------------------------------------------------------------------------
+// Deduction guides
+//------------------------------------------------------------------------------
+
+template <typename KC, typename MC, typename Comp = std::less<typename KC::value_type>>
+requires( !std::is_same_v<KC, sorted_unique_t> )
+flat_map( KC, MC, Comp = Comp{} )
+    -> flat_map<typename KC::value_type, typename MC::value_type, Comp, KC, MC>;
+
+template <typename KC, typename MC, typename Comp = std::less<typename KC::value_type>>
+flat_map( sorted_unique_t, KC, MC, Comp = Comp{} )
+    -> flat_map<typename KC::value_type, typename MC::value_type, Comp, KC, MC>;
+
+template <std::input_iterator InputIt, typename Comp = std::less<std::remove_const_t<typename std::iterator_traits<InputIt>::value_type::first_type>>>
+requires( !std::is_same_v<InputIt, sorted_unique_t> )
+flat_map( InputIt, InputIt, Comp = Comp{} )
+    -> flat_map<std::remove_const_t<typename std::iterator_traits<InputIt>::value_type::first_type>,
+                typename std::iterator_traits<InputIt>::value_type::second_type,
+                Comp>;
+
+template <std::input_iterator InputIt, typename Comp = std::less<std::remove_const_t<typename std::iterator_traits<InputIt>::value_type::first_type>>>
+flat_map( sorted_unique_t, InputIt, InputIt, Comp = Comp{} )
+    -> flat_map<std::remove_const_t<typename std::iterator_traits<InputIt>::value_type::first_type>,
+                typename std::iterator_traits<InputIt>::value_type::second_type,
+                Comp>;
+
+template <std::ranges::input_range R, typename Comp = std::less<std::remove_const_t<typename std::ranges::range_value_t<R>::first_type>>>
+flat_map( std::from_range_t, R &&, Comp = Comp{} )
+    -> flat_map<std::remove_const_t<typename std::ranges::range_value_t<R>::first_type>,
+                typename std::ranges::range_value_t<R>::second_type,
+                Comp>;
+
+template <typename Key, typename T, typename Comp = std::less<Key>>
+flat_map( std::initializer_list<std::pair<Key, T>>, Comp = Comp{} )
+    -> flat_map<Key, T, Comp>;
+
+template <typename Key, typename T, typename Comp = std::less<Key>>
+flat_map( sorted_unique_t, std::initializer_list<std::pair<Key, T>>, Comp = Comp{} )
+    -> flat_map<Key, T, Comp>;
+
+//------------------------------------------------------------------------------
+} // namespace psi::vm
+//------------------------------------------------------------------------------

--- a/src/containers/vm_vector.cpp
+++ b/src/containers/vm_vector.cpp
@@ -25,7 +25,7 @@ namespace psi::vm
 
 namespace detail
 {
-    [[ noreturn, gnu::cold ]] void throw_out_of_range() { throw std::out_of_range( "vm::vector access out of bounds" ); }
+    [[ noreturn, gnu::cold ]] void throw_out_of_range( char const * const msg ) { throw std::out_of_range( msg ); }
 #if PSI_MALLOC_OVERCOMMIT != PSI_OVERCOMMIT_Full
     [[ noreturn, gnu::cold ]] void throw_bad_alloc   () { throw std::bad_alloc(); }
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 set( vm_test_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/b+tree.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/flat_map.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/vector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/vm_vector.cpp"
 )
@@ -28,18 +29,5 @@ set_target_properties(
 )
 
 PSI_target_fix_debug_symbols_for_osx_lto( vm_unit_tests )
-
-if ( NOT APPLE ) # crashes on GH?
-    gtest_discover_tests(
-        vm_unit_tests
-        EXTRA_ARGS
-        --gtest_color=auto
-        --gtest_output=xml:${CMAKE_BINARY_DIR}/test/vm_unit_tests.xml
-        --gtest_catch_exceptions=1
-        DISCOVERY_TIMEOUT 120
-        PROPERTIES
-        TIMEOUT 120
-    )
-endif()
 
 add_test( "vm_unit_tests" vm_unit_tests )

--- a/test/flat_map.cpp
+++ b/test/flat_map.cpp
@@ -1,0 +1,1322 @@
+////////////////////////////////////////////////////////////////////////////////
+/// psi::vm::flat_map unit tests
+////////////////////////////////////////////////////////////////////////////////
+
+#include <psi/vm/containers/flat_map.hpp>
+#include <psi/vm/containers/tr_vector.hpp>
+#include <psi/vm/containers/is_trivially_moveable.hpp>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+//------------------------------------------------------------------------------
+namespace psi::vm {
+//------------------------------------------------------------------------------
+
+//==============================================================================
+// Construction
+//==============================================================================
+
+TEST( flat_map, default_construction )
+{
+    flat_map<int, std::string> m;
+    EXPECT_TRUE ( m.empty() );
+    EXPECT_EQ   ( m.size(), 0 );
+    EXPECT_EQ   ( m.begin(), m.end() );
+}
+
+TEST( flat_map, sorted_unique_construction )
+{
+    std::vector<int>         keys  { 1, 3, 5, 7 };
+    std::vector<std::string> values{ "a", "b", "c", "d" };
+    flat_map<int, std::string> m( sorted_unique, std::move( keys ), std::move( values ) );
+
+    EXPECT_EQ( m.size(), 4 );
+    EXPECT_EQ( m.at( 1 ), "a" );
+    EXPECT_EQ( m.at( 3 ), "b" );
+    EXPECT_EQ( m.at( 5 ), "c" );
+    EXPECT_EQ( m.at( 7 ), "d" );
+}
+
+TEST( flat_map, range_construction )
+{
+    std::vector<std::pair<int, std::string>> pairs{
+        { 5, "e" }, { 1, "a" }, { 3, "c" }, { 1, "dup" }
+    };
+    flat_map<int, std::string> m( pairs.begin(), pairs.end() );
+
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m.at( 1 ), "a" ); // first wins
+    EXPECT_EQ( m.at( 3 ), "c" );
+    EXPECT_EQ( m.at( 5 ), "e" );
+}
+
+TEST( flat_map, initializer_list_construction )
+{
+    flat_map<int, int> m{ { 3, 30 }, { 1, 10 }, { 2, 20 } };
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m.at( 1 ), 10 );
+    EXPECT_EQ( m.at( 2 ), 20 );
+    EXPECT_EQ( m.at( 3 ), 30 );
+}
+
+TEST( flat_map, copy_construction )
+{
+    flat_map<int, int> src{ { 1, 10 }, { 2, 20 } };
+    flat_map<int, int> dst{ src };
+    EXPECT_EQ( dst.size(), 2 );
+    EXPECT_EQ( dst.at( 1 ), 10 );
+    EXPECT_EQ( dst.at( 2 ), 20 );
+    // Verify independence
+    src[ 1 ] = 99;
+    EXPECT_EQ( dst.at( 1 ), 10 );
+}
+
+TEST( flat_map, move_construction )
+{
+    flat_map<int, int> src{ { 1, 10 }, { 2, 20 } };
+    flat_map<int, int> dst{ std::move( src ) };
+    EXPECT_EQ( dst.size(), 2 );
+    EXPECT_EQ( dst.at( 1 ), 10 );
+}
+
+//==============================================================================
+// Element access
+//==============================================================================
+
+TEST( flat_map, operator_bracket_insert_and_access )
+{
+    flat_map<int, int> m;
+    m[ 3 ] = 30;
+    m[ 1 ] = 10;
+    m[ 2 ] = 20;
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m[ 1 ], 10 );
+    EXPECT_EQ( m[ 2 ], 20 );
+    EXPECT_EQ( m[ 3 ], 30 );
+
+    // operator[] on existing key doesn't insert
+    m[ 1 ] = 99;
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m[ 1 ], 99 );
+}
+
+TEST( flat_map, at_throws_on_missing )
+{
+    flat_map<int, int> m{ { 1, 10 } };
+    EXPECT_EQ( m.at( 1 ), 10 );
+    EXPECT_THROW( m.at( 2 ), std::out_of_range );
+}
+
+TEST( flat_map, const_at )
+{
+    flat_map<int, int> const m{ { 1, 10 }, { 2, 20 } };
+    EXPECT_EQ( m.at( 1 ), 10 );
+    EXPECT_THROW( m.at( 99 ), std::out_of_range );
+}
+
+//==============================================================================
+// Insertion
+//==============================================================================
+
+TEST( flat_map, try_emplace )
+{
+    flat_map<int, std::string> m;
+    auto [it1, ok1] = m.try_emplace( 2, "two" );
+    EXPECT_TRUE ( ok1 );
+    EXPECT_EQ   ( it1->first, 2 );
+    EXPECT_EQ   ( it1->second, "two" );
+
+    auto [it2, ok2] = m.try_emplace( 2, "TWO" );
+    EXPECT_FALSE( ok2 );
+    EXPECT_EQ   ( it2->second, "two" ); // not overwritten
+}
+
+TEST( flat_map, insert )
+{
+    flat_map<int, int> m;
+    auto [it, ok] = m.insert( { 5, 50 } );
+    EXPECT_TRUE( ok );
+    EXPECT_EQ  ( it->first, 5 );
+    EXPECT_EQ  ( it->second, 50 );
+
+    auto [it2, ok2] = m.insert( { 5, 99 } );
+    EXPECT_FALSE( ok2 );
+    EXPECT_EQ   ( it2->second, 50 );
+}
+
+TEST( flat_map, insert_or_assign )
+{
+    flat_map<int, int> m;
+    auto [it1, ok1] = m.insert_or_assign( 1, 10 );
+    EXPECT_TRUE( ok1 );
+    EXPECT_EQ  ( it1->second, 10 );
+
+    auto [it2, ok2] = m.insert_or_assign( 1, 99 );
+    EXPECT_FALSE( ok2 );
+    EXPECT_EQ   ( it2->second, 99 ); // overwritten
+}
+
+TEST( flat_map, emplace )
+{
+    flat_map<int, std::string> m;
+    auto [it, ok] = m.emplace( 3, "three" );
+    EXPECT_TRUE( ok );
+    EXPECT_EQ  ( it->first, 3 );
+}
+
+TEST( flat_map, emplace_hint_sorted_input )
+{
+    flat_map<int, int> m;
+    // Insert in sorted order with end() hint — should be O(1) each
+    for ( int i{ 0 }; i < 100; ++i ) {
+        m.emplace_hint( m.end(), i, i * 10 );
+    }
+    EXPECT_EQ( m.size(), 100 );
+    for ( int i{ 0 }; i < 100; ++i ) {
+        EXPECT_EQ( m.at( i ), i * 10 );
+    }
+}
+
+TEST( flat_map, emplace_hint_wrong_hint )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 5, 50 }, { 9, 90 } };
+    // Wrong hint: insert 3 with hint at begin (should be between 1 and 5)
+    auto it = m.emplace_hint( m.begin(), 3, 30 );
+    EXPECT_EQ( it->first, 3 );
+    EXPECT_EQ( it->second, 30 );
+    EXPECT_EQ( m.size(), 4 );
+    // Verify sorted order
+    auto const & keys = m.keys();
+    EXPECT_TRUE( std::is_sorted( keys.begin(), keys.end() ) );
+}
+
+TEST( flat_map, emplace_hint_existing_key )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 5, 50 } };
+    auto it = m.emplace_hint( m.begin() + 1, 5, 99 );
+    EXPECT_EQ( it->first , 5 );
+    EXPECT_EQ( it->second, 50 ); // not overwritten
+    EXPECT_EQ( m.size(), 2 );
+}
+
+//==============================================================================
+// Lookup
+//==============================================================================
+
+TEST( flat_map, find_hit_and_miss )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 3, 30 }, { 5, 50 } };
+    auto it = m.find( 3 );
+    ASSERT_NE( it, m.end() );
+    EXPECT_EQ( it->second, 30 );
+
+    EXPECT_EQ( m.find( 2 ), m.end() );
+    EXPECT_EQ( m.find( 0 ), m.end() );
+    EXPECT_EQ( m.find( 99 ), m.end() );
+}
+
+TEST( flat_map, lower_upper_bound )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 3, 30 }, { 5, 50 } };
+    auto lb = m.lower_bound( 3 );
+    EXPECT_EQ( lb->first, 3 );
+    auto ub = m.upper_bound( 3 );
+    EXPECT_EQ( ub->first, 5 );
+
+    auto lb2 = m.lower_bound( 2 );
+    EXPECT_EQ( lb2->first, 3 ); // first element >= 2
+}
+
+TEST( flat_map, equal_range )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 3, 30 }, { 5, 50 } };
+    auto [lo, hi] = m.equal_range( 3 );
+    EXPECT_EQ( lo->first, 3 );
+    EXPECT_EQ( hi->first, 5 );
+    EXPECT_EQ( hi - lo, 1 );
+}
+
+TEST( flat_map, contains_and_count )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 3, 30 } };
+    EXPECT_TRUE ( m.contains( 1 ) );
+    EXPECT_FALSE( m.contains( 2 ) );
+    EXPECT_EQ   ( m.count( 1 ), 1 );
+    EXPECT_EQ   ( m.count( 2 ), 0 );
+}
+
+TEST( flat_map, transparent_comparison )
+{
+    // std::less<> has is_transparent
+    flat_map<int, std::string, std::less<>> m{ { 1, "a" }, { 3, "c" } };
+    // Should compile and work with different key types (e.g. long)
+    EXPECT_TRUE( m.contains( 1L ) );
+    EXPECT_NE  ( m.find( 3L ), m.end() );
+    auto lb = m.lower_bound( 2L );
+    EXPECT_EQ( lb->first, 3 );
+}
+
+//==============================================================================
+// Erasure
+//==============================================================================
+
+TEST( flat_map, erase_by_key )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 }, { 3, 30 } };
+    EXPECT_EQ( m.erase( 2 ), 1 );
+    EXPECT_EQ( m.size(), 2 );
+    EXPECT_FALSE( m.contains( 2 ) );
+
+    EXPECT_EQ( m.erase( 99 ), 0 );
+    EXPECT_EQ( m.size(), 2 );
+}
+
+TEST( flat_map, erase_by_iterator )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 }, { 3, 30 } };
+    auto it = m.find( 2 );
+    auto next = m.erase( it );
+    EXPECT_EQ( m.size(), 2 );
+    EXPECT_EQ( next->first, 3 );
+}
+
+TEST( flat_map, erase_range )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 }, { 3, 30 }, { 4, 40 } };
+    auto first = m.find( 2 );
+    auto last  = m.find( 4 );
+    m.erase( first, last );
+    EXPECT_EQ( m.size(), 2 );
+    EXPECT_TRUE ( m.contains( 1 ) );
+    EXPECT_FALSE( m.contains( 2 ) );
+    EXPECT_FALSE( m.contains( 3 ) );
+    EXPECT_TRUE ( m.contains( 4 ) );
+}
+
+//==============================================================================
+// Extract and Replace
+//==============================================================================
+
+TEST( flat_map, extract_and_replace )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 }, { 3, 30 } };
+    auto c = m.extract();
+    EXPECT_TRUE( m.empty() );
+    EXPECT_EQ( c.keys.size(), 3 );
+    EXPECT_EQ( c.values.size(), 3 );
+
+    // Modify extracted containers
+    c.keys.push_back( 4 );
+    c.values.push_back( 40 );
+
+    m.replace( std::move( c.keys ), std::move( c.values ) );
+    EXPECT_EQ( m.size(), 4 );
+    EXPECT_EQ( m.at( 4 ), 40 );
+}
+
+//==============================================================================
+// Keys and Values accessors
+//==============================================================================
+
+TEST( flat_map, keys_returns_sorted_contiguous )
+{
+    flat_map<int, int> m{ { 5, 50 }, { 1, 10 }, { 3, 30 } };
+    auto const & keys = m.keys();
+    ASSERT_EQ( keys.size(), 3 );
+    EXPECT_EQ( keys[ 0 ], 1 );
+    EXPECT_EQ( keys[ 1 ], 3 );
+    EXPECT_EQ( keys[ 2 ], 5 );
+    EXPECT_TRUE( std::is_sorted( keys.begin(), keys.end() ) );
+
+    // Verify contiguous (can form span)
+    std::span<int const> keySpan{ keys.data(), keys.size() };
+    EXPECT_EQ( keySpan[ 1 ], 3 );
+}
+
+TEST( flat_map, values_in_key_order )
+{
+    flat_map<int, std::string> m{ { 3, "c" }, { 1, "a" }, { 2, "b" } };
+    auto const & vals = m.values();
+    EXPECT_EQ( vals[ 0 ], "a" ); // key=1
+    EXPECT_EQ( vals[ 1 ], "b" ); // key=2
+    EXPECT_EQ( vals[ 2 ], "c" ); // key=3
+}
+
+//==============================================================================
+// Merge
+//==============================================================================
+
+TEST( flat_map, merge_non_overlapping )
+{
+    flat_map<int, int> a{ { 1, 10 }, { 3, 30 } };
+    flat_map<int, int> b{ { 2, 20 }, { 4, 40 } };
+    a.merge( b );
+    EXPECT_EQ( a.size(), 4 );
+    EXPECT_TRUE( b.empty() );
+    EXPECT_EQ( a.at( 2 ), 20 );
+    EXPECT_EQ( a.at( 4 ), 40 );
+}
+
+TEST( flat_map, merge_overlapping )
+{
+    flat_map<int, int> a{ { 1, 10 }, { 3, 30 } };
+    flat_map<int, int> b{ { 2, 20 }, { 3, 99 } };
+    a.merge( b );
+    EXPECT_EQ( a.size(), 3 );
+    EXPECT_EQ( a.at( 3 ), 30 ); // original kept
+    EXPECT_EQ( b.size(), 1 );   // conflicting element remains in source
+    EXPECT_EQ( b.at( 3 ), 99 );
+}
+
+//==============================================================================
+// Iterator
+//==============================================================================
+
+TEST( flat_map, iterator_random_access )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 }, { 3, 30 } };
+    auto it = m.begin();
+    EXPECT_EQ( ( it + 2 )->first, 3 );
+    EXPECT_EQ( it[ 1 ].first, 2 );
+    EXPECT_EQ( m.end() - m.begin(), 3 );
+    EXPECT_LT( m.begin(), m.end() );
+}
+
+TEST( flat_map, iterator_structured_bindings )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 } };
+    for ( auto [key, val] : m ) {
+        EXPECT_EQ( val, key * 10 );
+    }
+}
+
+TEST( flat_map, iterator_mutable_value )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 } };
+    auto it = m.find( 1 );
+    it->second = 99;
+    EXPECT_EQ( m.at( 1 ), 99 );
+}
+
+TEST( flat_map, iterator_arrow_proxy_address_stability )
+{
+    // Verify that &(it->second) yields a stable address into the values container
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 }, { 3, 30 } };
+    auto it = m.find( 2 );
+    int * addr = &( it->second );
+    EXPECT_EQ( *addr, 20 );
+    *addr = 99;
+    EXPECT_EQ( m.at( 2 ), 99 );
+}
+
+TEST( flat_map, const_iterator )
+{
+    flat_map<int, int> const m{ { 1, 10 }, { 2, 20 } };
+    auto it = m.begin();
+    EXPECT_EQ( it->first, 1 );
+    EXPECT_EQ( it->second, 10 );
+    // Should NOT compile: it->second = 99;
+}
+
+TEST( flat_map, reverse_iterator )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 }, { 3, 30 } };
+    auto rit = m.rbegin();
+    EXPECT_EQ( rit->first, 3 );
+    ++rit;
+    EXPECT_EQ( rit->first, 2 );
+}
+
+//==============================================================================
+// Edge cases
+//==============================================================================
+
+TEST( flat_map, empty_map_operations )
+{
+    flat_map<int, int> m;
+    EXPECT_EQ( m.find( 1 ), m.end() );
+    EXPECT_FALSE( m.contains( 1 ) );
+    EXPECT_EQ( m.count( 1 ), 0 );
+    EXPECT_EQ( m.erase( 1 ), 0 );
+    EXPECT_EQ( m.lower_bound( 1 ), m.end() );
+    EXPECT_EQ( m.upper_bound( 1 ), m.end() );
+}
+
+TEST( flat_map, single_element )
+{
+    flat_map<int, int> m{ { 42, 420 } };
+    EXPECT_EQ( m.size(), 1 );
+    EXPECT_EQ( m.at( 42 ), 420 );
+    EXPECT_EQ( m.begin()->first, 42 );
+    EXPECT_EQ( m.end() - m.begin(), 1 );
+    m.erase( m.begin() );
+    EXPECT_TRUE( m.empty() );
+}
+
+TEST( flat_map, duplicate_key_insertion )
+{
+    flat_map<int, int> m;
+    m.try_emplace( 1, 10 );
+    m.try_emplace( 1, 20 );
+    m.try_emplace( 1, 30 );
+    EXPECT_EQ( m.size(), 1 );
+    EXPECT_EQ( m.at( 1 ), 10 ); // first insertion wins
+}
+
+TEST( flat_map, swap )
+{
+    flat_map<int, int> a{ { 1, 10 } };
+    flat_map<int, int> b{ { 2, 20 }, { 3, 30 } };
+    a.swap( b );
+    EXPECT_EQ( a.size(), 2 );
+    EXPECT_EQ( b.size(), 1 );
+    EXPECT_EQ( a.at( 2 ), 20 );
+    EXPECT_EQ( b.at( 1 ), 10 );
+}
+
+TEST( flat_map, clear )
+{
+    flat_map<int, int> m{ { 1, 10 }, { 2, 20 } };
+    m.clear();
+    EXPECT_TRUE( m.empty() );
+    EXPECT_EQ( m.size(), 0 );
+    // Should be usable again
+    m[ 3 ] = 30;
+    EXPECT_EQ( m.at( 3 ), 30 );
+}
+
+TEST( flat_map, comparison )
+{
+    flat_map<int, int> a{ { 1, 10 }, { 2, 20 } };
+    flat_map<int, int> b{ { 1, 10 }, { 2, 20 } };
+    flat_map<int, int> c{ { 1, 10 }, { 3, 30 } };
+    EXPECT_EQ( a, b );
+    EXPECT_NE( a, c );
+}
+
+TEST( flat_map, reserve_and_shrink )
+{
+    flat_map<int, int> m;
+    m.reserve( 100 );
+    for ( int i{ 0 }; i < 50; ++i ) {
+        m.emplace_hint( m.end(), i, i * 10 );
+    }
+    EXPECT_EQ( m.size(), 50 );
+    m.shrink_to_fit();
+    EXPECT_EQ( m.size(), 50 );
+}
+
+//==============================================================================
+// tr_vector containers
+//==============================================================================
+
+// flat_map using psi::vm::tr_vector as underlying storage
+using tr_flat_map_ii = flat_map<int, int, std::less<int>, tr_vector<int>, tr_vector<int>>;
+
+TEST( flat_map, tr_vector_basic )
+{
+    tr_flat_map_ii m;
+    m[ 3 ] = 30;
+    m[ 1 ] = 10;
+    m[ 2 ] = 20;
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m.at( 1 ), 10 );
+    EXPECT_EQ( m.at( 2 ), 20 );
+    EXPECT_EQ( m.at( 3 ), 30 );
+}
+
+TEST( flat_map, tr_vector_sorted_unique_construction )
+{
+    tr_vector<int> keys;
+    keys.push_back( 1 ); keys.push_back( 3 ); keys.push_back( 5 );
+    tr_vector<int> vals;
+    vals.push_back( 10 ); vals.push_back( 30 ); vals.push_back( 50 );
+    tr_flat_map_ii m( sorted_unique, std::move( keys ), std::move( vals ) );
+
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m.at( 1 ), 10 );
+    EXPECT_EQ( m.at( 3 ), 30 );
+    EXPECT_EQ( m.at( 5 ), 50 );
+}
+
+TEST( flat_map, tr_vector_emplace_hint_sorted )
+{
+    tr_flat_map_ii m;
+    for ( int i{ 0 }; i < 100; ++i ) {
+        m.emplace_hint( m.end(), i, i * 10 );
+    }
+    EXPECT_EQ( m.size(), 100 );
+    auto const & keys{ m.keys() };
+    EXPECT_TRUE( std::is_sorted( keys.begin(), keys.end() ) );
+    EXPECT_EQ( m.at( 42 ), 420 );
+}
+
+TEST( flat_map, tr_vector_extract_replace )
+{
+    tr_flat_map_ii m;
+    m[ 1 ] = 10; m[ 2 ] = 20;
+    auto c{ m.extract() };
+    EXPECT_TRUE( m.empty() );
+    EXPECT_EQ( c.keys.size(), 2 );
+    c.keys.push_back( 3 );
+    c.values.push_back( 30 );
+    m.replace( std::move( c.keys ), std::move( c.values ) );
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m.at( 3 ), 30 );
+}
+
+TEST( flat_map, tr_vector_keys_span )
+{
+    tr_flat_map_ii m;
+    m[ 5 ] = 50; m[ 1 ] = 10; m[ 3 ] = 30;
+    auto const & keys{ m.keys() };
+    // tr_vector is contiguous — can form a span for cache-friendly key-only iteration
+    std::span<int const> keySpan{ keys.data(), keys.size() };
+    EXPECT_EQ( keySpan.size(), 3 );
+    EXPECT_EQ( keySpan[ 0 ], 1 );
+    EXPECT_EQ( keySpan[ 1 ], 3 );
+    EXPECT_EQ( keySpan[ 2 ], 5 );
+}
+
+TEST( flat_map, tr_vector_erase_and_find )
+{
+    tr_flat_map_ii m;
+    m[ 1 ] = 10; m[ 2 ] = 20; m[ 3 ] = 30;
+    EXPECT_EQ( m.erase( 2 ), 1 );
+    EXPECT_EQ( m.size(), 2 );
+    EXPECT_EQ( m.find( 2 ), m.end() );
+    EXPECT_NE( m.find( 1 ), m.end() );
+    EXPECT_NE( m.find( 3 ), m.end() );
+}
+
+TEST( flat_map, tr_vector_merge )
+{
+    tr_flat_map_ii a;
+    a[ 1 ] = 10; a[ 3 ] = 30;
+    tr_flat_map_ii b;
+    b[ 2 ] = 20; b[ 4 ] = 40;
+    a.merge( b );
+    EXPECT_EQ( a.size(), 4 );
+    EXPECT_TRUE( b.empty() );
+    EXPECT_EQ( a.at( 2 ), 20 );
+}
+
+TEST( flat_map, tr_vector_reserve_and_shrink )
+{
+    tr_flat_map_ii m;
+    m.reserve( 100 );
+    for ( int i{ 0 }; i < 50; ++i ) {
+        m.emplace_hint( m.end(), i, i * 10 );
+    }
+    EXPECT_EQ( m.size(), 50 );
+    m.shrink_to_fit();
+    EXPECT_EQ( m.size(), 50 );
+    EXPECT_EQ( m.at( 25 ), 250 );
+}
+
+//==============================================================================
+// Transparent comparator (std::less<>)
+//==============================================================================
+
+// flat_map with std::less<> and std::vector — exercises heterogeneous lookup
+using tr_less_map = flat_map<int, int, std::less<>>;
+
+TEST( flat_map, transparent_find_with_various_types )
+{
+    tr_less_map m{ { 1, 10 }, { 3, 30 }, { 5, 50 } };
+
+    // Find with long
+    auto it1{ m.find( 3L ) };
+    ASSERT_NE( it1, m.end() );
+    EXPECT_EQ( it1->second, 30 );
+
+    // Find with unsigned
+    auto it2{ m.find( 5U ) };
+    ASSERT_NE( it2, m.end() );
+    EXPECT_EQ( it2->second, 50 );
+
+    // Find with short
+    auto it3{ m.find( static_cast<short>( 1 ) ) };
+    ASSERT_NE( it3, m.end() );
+    EXPECT_EQ( it3->second, 10 );
+
+    // Miss
+    EXPECT_EQ( m.find( 2L ), m.end() );
+}
+
+TEST( flat_map, transparent_lower_upper_bound )
+{
+    tr_less_map m{ { 10, 100 }, { 20, 200 }, { 30, 300 } };
+
+    auto lb{ m.lower_bound( 15L ) };
+    EXPECT_EQ( lb->first, 20 );
+
+    auto ub{ m.upper_bound( 20L ) };
+    EXPECT_EQ( ub->first, 30 );
+
+    auto [lo, hi]{ m.equal_range( 20U ) };
+    EXPECT_EQ( lo->first, 20 );
+    EXPECT_EQ( hi->first, 30 );
+}
+
+TEST( flat_map, transparent_contains_count )
+{
+    tr_less_map m{ { 1, 10 }, { 3, 30 } };
+    EXPECT_TRUE ( m.contains( 1L  ) );
+    EXPECT_TRUE ( m.contains( 3U  ) );
+    EXPECT_FALSE( m.contains( 2L  ) );
+    EXPECT_EQ   ( m.count( 1L  ), 1 );
+    EXPECT_EQ   ( m.count( 99U ), 0 );
+}
+
+// flat_map with std::less<> and tr_vector — the combination used in rama
+using tr_vec_less_map = flat_map<int, int, std::less<>, tr_vector<int>, tr_vector<int>>;
+
+TEST( flat_map, tr_vector_transparent_combined )
+{
+    tr_vec_less_map m;
+    m[ 5 ] = 50; m[ 1 ] = 10; m[ 3 ] = 30;
+
+    // Heterogeneous lookup
+    EXPECT_TRUE( m.contains( 3L  ) );
+    EXPECT_TRUE( m.contains( 5U  ) );
+    EXPECT_FALSE( m.contains( 2L ) );
+
+    auto it{ m.find( 1L ) };
+    ASSERT_NE( it, m.end() );
+    EXPECT_EQ( it->second, 10 );
+
+    auto lb{ m.lower_bound( 2U ) };
+    EXPECT_EQ( lb->first, 3 );
+
+    // Keys span — the actual use case for DimMembersSpan
+    auto const & keys{ m.keys() };
+    std::span<int const> keySpan{ keys.data(), keys.size() };
+    EXPECT_EQ( keySpan[ 0 ], 1 );
+    EXPECT_EQ( keySpan[ 1 ], 3 );
+    EXPECT_EQ( keySpan[ 2 ], 5 );
+}
+
+TEST( flat_map, tr_vector_transparent_emplace_hint_and_erase )
+{
+    tr_vec_less_map m;
+    for ( int i{ 0 }; i < 50; ++i ) {
+        m.emplace_hint( m.end(), i, i * 10 );
+    }
+    EXPECT_EQ( m.size(), 50 );
+
+    // Heterogeneous find + erase
+    auto it{ m.find( 25L ) };
+    ASSERT_NE( it, m.end() );
+    m.erase( it );
+    EXPECT_EQ( m.size(), 49 );
+    EXPECT_FALSE( m.contains( 25U ) );
+
+    // Verify sorted invariant
+    auto const & keys{ m.keys() };
+    EXPECT_TRUE( std::is_sorted( keys.begin(), keys.end() ) );
+}
+
+// Type aliases for new tests
+using FM          = flat_map<int, int>;
+using tr_vec_map  = flat_map<int, int, std::less<int>, tr_vector<int, std::uint32_t>, tr_vector<int, std::uint32_t>>;
+
+//==============================================================================
+// New feature tests: insert_range, bulk insert, merge rewrite, erase_if,
+// from_range_t, deduction guides, transparent at/operator[], sorted_unique inserts
+//==============================================================================
+
+TEST( flat_map, insert_range_basic )
+{
+    FM m{ { 1, 10 }, { 3, 30 }, { 5, 50 } };
+    std::vector<std::pair<int, int>> src{ { 2, 20 }, { 4, 40 }, { 6, 60 } };
+    m.insert_range( src );
+    EXPECT_EQ( m.size(), 6 );
+    for ( int i{ 1 }; i <= 6; ++i )
+        EXPECT_EQ( m.at( i ), i * 10 );
+}
+
+TEST( flat_map, insert_range_with_duplicates )
+{
+    FM m{ { 1, 10 }, { 3, 30 }, { 5, 50 } };
+    std::vector<std::pair<int, int>> src{ { 3, 999 }, { 5, 888 }, { 7, 70 } };
+    m.insert_range( src );
+    EXPECT_EQ( m.size(), 4 );
+    // Existing values win
+    EXPECT_EQ( m.at( 3 ), 30 );
+    EXPECT_EQ( m.at( 5 ), 50 );
+    EXPECT_EQ( m.at( 7 ), 70 );
+}
+
+TEST( flat_map, insert_range_into_empty )
+{
+    FM m;
+    std::vector<std::pair<int, int>> src{ { 5, 50 }, { 1, 10 }, { 3, 30 } };
+    m.insert_range( src );
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_TRUE( std::is_sorted( m.keys().begin(), m.keys().end() ) );
+    EXPECT_EQ( m.at( 1 ), 10 );
+    EXPECT_EQ( m.at( 3 ), 30 );
+    EXPECT_EQ( m.at( 5 ), 50 );
+}
+
+TEST( flat_map, insert_range_sorted_unique )
+{
+    FM m{ { 2, 20 }, { 4, 40 } };
+    std::vector<std::pair<int, int>> src{ { 1, 10 }, { 3, 30 }, { 5, 50 } };
+    m.insert_range( psi::vm::sorted_unique, src );
+    EXPECT_EQ( m.size(), 5 );
+    for ( int i{ 1 }; i <= 5; ++i )
+        EXPECT_EQ( m.at( i ), i * 10 );
+}
+
+TEST( flat_map, insert_range_empty_range )
+{
+    FM m{ { 1, 10 } };
+    std::vector<std::pair<int, int>> empty;
+    m.insert_range( empty );
+    EXPECT_EQ( m.size(), 1 );
+}
+
+TEST( flat_map, bulk_insert_range_iterator )
+{
+    // insert(InputIt, InputIt) now uses bulk algorithm
+    FM m{ { 1, 10 }, { 5, 50 } };
+    std::vector<std::pair<int, int>> src{ { 3, 30 }, { 2, 20 }, { 4, 40 }, { 1, 999 } };
+    m.insert( src.begin(), src.end() );
+    EXPECT_EQ( m.size(), 5 );
+    EXPECT_EQ( m.at( 1 ), 10 ); // existing wins
+    EXPECT_EQ( m.at( 2 ), 20 );
+    EXPECT_EQ( m.at( 3 ), 30 );
+}
+
+TEST( flat_map, insert_sorted_unique_range )
+{
+    FM m{ { 2, 20 }, { 6, 60 } };
+    std::vector<std::pair<int, int>> src{ { 1, 10 }, { 4, 40 }, { 8, 80 } };
+    m.insert( psi::vm::sorted_unique, src.begin(), src.end() );
+    EXPECT_EQ( m.size(), 5 );
+    EXPECT_TRUE( std::is_sorted( m.keys().begin(), m.keys().end() ) );
+}
+
+TEST( flat_map, insert_sorted_unique_initializer_list )
+{
+    FM m{ { 2, 20 } };
+    m.insert( psi::vm::sorted_unique, { { 1, 10 }, { 3, 30 } } );
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m.at( 1 ), 10 );
+}
+
+TEST( flat_map, merge_lvalue_bulk )
+{
+    FM target{ { 1, 10 }, { 3, 30 }, { 5, 50 } };
+    FM source{ { 2, 20 }, { 3, 999 }, { 4, 40 } };
+    target.merge( source );
+    // target gets 2 and 4, not 3 (already exists)
+    EXPECT_EQ( target.size(), 5 );
+    EXPECT_EQ( target.at( 1 ), 10 );
+    EXPECT_EQ( target.at( 2 ), 20 );
+    EXPECT_EQ( target.at( 3 ), 30 ); // original wins
+    EXPECT_EQ( target.at( 4 ), 40 );
+    EXPECT_EQ( target.at( 5 ), 50 );
+    // source retains only the duplicate
+    EXPECT_EQ( source.size(), 1 );
+    EXPECT_TRUE( source.contains( 3 ) );
+}
+
+TEST( flat_map, merge_rvalue_bulk )
+{
+    FM target{ { 1, 10 }, { 3, 30 } };
+    FM source{ { 2, 20 }, { 3, 999 }, { 4, 40 } };
+    target.merge( std::move( source ) );
+    EXPECT_EQ( target.size(), 4 );
+    EXPECT_EQ( target.at( 3 ), 30 ); // existing wins
+    EXPECT_EQ( target.at( 2 ), 20 );
+    EXPECT_EQ( target.at( 4 ), 40 );
+    // source is cleared
+    EXPECT_TRUE( source.empty() );
+}
+
+TEST( flat_map, merge_empty_source )
+{
+    FM target{ { 1, 10 } };
+    FM source;
+    target.merge( source );
+    EXPECT_EQ( target.size(), 1 );
+}
+
+TEST( flat_map, merge_empty_target )
+{
+    FM target;
+    FM source{ { 1, 10 }, { 2, 20 } };
+    target.merge( source );
+    EXPECT_EQ( target.size(), 2 );
+    EXPECT_TRUE( source.empty() );
+}
+
+TEST( flat_map, merge_self )
+{
+    FM m{ { 1, 10 }, { 2, 20 } };
+    m.merge( m );
+    EXPECT_EQ( m.size(), 2 ); // no change
+}
+
+TEST( flat_map, erase_if_basic )
+{
+    FM m{ { 1, 10 }, { 2, 20 }, { 3, 30 }, { 4, 40 }, { 5, 50 } };
+    auto const erased{ erase_if( m, []( auto const & kv ) { return kv.first % 2 == 0; } ) };
+    EXPECT_EQ( erased, 2 );
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_TRUE( m.contains( 1 ) );
+    EXPECT_FALSE( m.contains( 2 ) );
+    EXPECT_TRUE( m.contains( 3 ) );
+    EXPECT_FALSE( m.contains( 4 ) );
+    EXPECT_TRUE( m.contains( 5 ) );
+}
+
+TEST( flat_map, erase_if_all )
+{
+    FM m{ { 1, 10 }, { 2, 20 } };
+    auto const erased{ erase_if( m, []( auto const & ) { return true; } ) };
+    EXPECT_EQ( erased, 2 );
+    EXPECT_TRUE( m.empty() );
+}
+
+TEST( flat_map, erase_if_none )
+{
+    FM m{ { 1, 10 }, { 2, 20 } };
+    auto const erased{ erase_if( m, []( auto const & ) { return false; } ) };
+    EXPECT_EQ( erased, 0 );
+    EXPECT_EQ( m.size(), 2 );
+}
+
+TEST( flat_map, erase_if_preserves_order )
+{
+    FM m{ { 1, 10 }, { 2, 20 }, { 3, 30 }, { 4, 40 }, { 5, 50 } };
+    erase_if( m, []( auto const & kv ) { return kv.second == 30; } );
+    EXPECT_TRUE( std::is_sorted( m.keys().begin(), m.keys().end() ) );
+    auto const & k{ m.keys() };
+    ASSERT_EQ( k.size(), 4 );
+    EXPECT_EQ( k[ 0 ], 1 );
+    EXPECT_EQ( k[ 1 ], 2 );
+    EXPECT_EQ( k[ 2 ], 4 );
+    EXPECT_EQ( k[ 3 ], 5 );
+}
+
+TEST( flat_map, from_range_t_construction )
+{
+    std::vector<std::pair<int, int>> src{ { 3, 30 }, { 1, 10 }, { 2, 20 } };
+    FM m( std::from_range, src );
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_TRUE( std::is_sorted( m.keys().begin(), m.keys().end() ) );
+    EXPECT_EQ( m.at( 1 ), 10 );
+    EXPECT_EQ( m.at( 2 ), 20 );
+    EXPECT_EQ( m.at( 3 ), 30 );
+}
+
+TEST( flat_map, from_range_t_with_duplicates )
+{
+    std::vector<std::pair<int, int>> src{ { 1, 10 }, { 1, 99 }, { 2, 20 } };
+    FM m( std::from_range, src );
+    EXPECT_EQ( m.size(), 2 );
+    EXPECT_EQ( m.at( 1 ), 10 ); // first occurrence wins
+}
+
+TEST( flat_map, unsorted_container_construction )
+{
+    std::vector<int> keys{ 3, 1, 2 };
+    std::vector<int> vals{ 30, 10, 20 };
+    FM m( std::move( keys ), std::move( vals ) );
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m.at( 1 ), 10 );
+    EXPECT_EQ( m.at( 2 ), 20 );
+    EXPECT_EQ( m.at( 3 ), 30 );
+}
+
+TEST( flat_map, unsorted_container_with_duplicates )
+{
+    std::vector<int> keys{ 3, 1, 3, 2 };
+    std::vector<int> vals{ 30, 10, 99, 20 };
+    FM m( std::move( keys ), std::move( vals ) );
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_EQ( m.at( 3 ), 30 ); // first occurrence wins after sort
+}
+
+TEST( flat_map, transparent_at )
+{
+    using less_map = psi::vm::flat_map<std::string, int, std::less<>>;
+    less_map m;
+    m.try_emplace( "alpha", 1 );
+    m.try_emplace( "beta", 2 );
+
+    // Transparent at with string_view
+    std::string_view sv{ "alpha" };
+    EXPECT_EQ( m.at( sv ), 1 );
+
+    auto const & cm{ m };
+    EXPECT_EQ( cm.at( sv ), 2 - 1 ); // const version
+
+    EXPECT_THROW( m.at( std::string_view{ "gamma" } ), std::out_of_range );
+}
+
+TEST( flat_map, transparent_operator_bracket )
+{
+    using less_map = psi::vm::flat_map<std::string, int, std::less<>>;
+    less_map m;
+    m.try_emplace( "x", 42 );
+
+    std::string_view sv{ "x" };
+    EXPECT_EQ( m[ sv ], 42 );
+
+    // Insert via transparent operator[]
+    std::string_view sv2{ "y" };
+    m[ sv2 ] = 99;
+    EXPECT_EQ( m.at( "y" ), 99 );
+}
+
+TEST( flat_map, transparent_erase )
+{
+    using less_map = psi::vm::flat_map<std::string, int, std::less<>>;
+    less_map m;
+    m.try_emplace( "a", 1 );
+    m.try_emplace( "b", 2 );
+    m.try_emplace( "c", 3 );
+
+    auto const erased{ m.erase( std::string_view{ "b" } ) };
+    EXPECT_EQ( erased, 1 );
+    EXPECT_EQ( m.size(), 2 );
+    EXPECT_FALSE( m.contains( std::string_view{ "b" } ) );
+}
+
+TEST( flat_map, insert_hint_value )
+{
+    FM m{ { 1, 10 }, { 5, 50 } };
+    auto it{ m.insert( m.begin() + 1, std::pair{ 3, 30 } ) };
+    EXPECT_EQ( it->first, 3 );
+    EXPECT_EQ( it->second, 30 );
+    EXPECT_EQ( m.size(), 3 );
+}
+
+TEST( flat_map, insert_or_assign_hinted )
+{
+    FM m{ { 1, 10 }, { 3, 30 }, { 5, 50 } };
+    // Hit: update existing
+    auto it{ m.insert_or_assign( m.begin() + 1, 3, 999 ) };
+    EXPECT_EQ( it->second, 999 );
+    EXPECT_EQ( m.size(), 3 );
+    // Miss: fallback to non-hinted
+    auto it2{ m.insert_or_assign( m.begin(), 4, 40 ) };
+    EXPECT_EQ( it2->second, 40 );
+    EXPECT_EQ( m.size(), 4 );
+}
+
+TEST( flat_map, initializer_list_assignment )
+{
+    FM m{ { 1, 10 } };
+    m = { { 2, 20 }, { 3, 30 } };
+    EXPECT_EQ( m.size(), 2 );
+    EXPECT_FALSE( m.contains( 1 ) );
+    EXPECT_EQ( m.at( 2 ), 20 );
+}
+
+TEST( flat_map, deduction_guide_initializer_list )
+{
+    psi::vm::flat_map m{ std::pair{ 1, 2 }, std::pair{ 3, 4 } };
+    static_assert( std::is_same_v<decltype( m )::key_type, int> );
+    static_assert( std::is_same_v<decltype( m )::mapped_type, int> );
+    EXPECT_EQ( m.size(), 2 );
+}
+
+TEST( flat_map, deduction_guide_sorted_unique_initializer_list )
+{
+    psi::vm::flat_map m( psi::vm::sorted_unique, { std::pair{ 1, 10 }, std::pair{ 2, 20 } } );
+    EXPECT_EQ( m.size(), 2 );
+    EXPECT_EQ( m.at( 1 ), 10 );
+}
+
+TEST( flat_map, deduction_guide_container_pair )
+{
+    std::vector<int> k{ 3, 1, 2 };
+    std::vector<double> v{ 3.0, 1.0, 2.0 };
+    psi::vm::flat_map m( std::move( k ), std::move( v ) );
+    static_assert( std::is_same_v<decltype( m )::key_type, int> );
+    static_assert( std::is_same_v<decltype( m )::mapped_type, double> );
+    EXPECT_EQ( m.size(), 3 );
+    EXPECT_DOUBLE_EQ( m.at( 1 ), 1.0 );
+}
+
+TEST( flat_map, deduction_guide_iterator_range )
+{
+    std::vector<std::pair<int, double>> src{ { 1, 1.0 }, { 2, 2.0 } };
+    psi::vm::flat_map m( src.begin(), src.end() );
+    static_assert( std::is_same_v<decltype( m )::key_type, int> );
+    static_assert( std::is_same_v<decltype( m )::mapped_type, double> );
+    EXPECT_EQ( m.size(), 2 );
+}
+
+TEST( flat_map, size_type_matches_smaller_container )
+{
+    // With std::vector, size_type should be size_t
+    static_assert( std::is_same_v<FM::size_type, std::size_t> );
+}
+
+// Test with tr_vector which has uint32_t size_type
+TEST( flat_map, tr_vector_insert_range )
+{
+    tr_vec_map m;
+    m.try_emplace( 1, 10 );
+    m.try_emplace( 5, 50 );
+    std::vector<std::pair<int, int>> src{ { 3, 30 }, { 2, 20 }, { 4, 40 } };
+    m.insert_range( src );
+    EXPECT_EQ( m.size(), 5 );
+    for ( int i{ 1 }; i <= 5; ++i )
+        EXPECT_EQ( m.at( i ), i * 10 );
+}
+
+TEST( flat_map, tr_vector_erase_if )
+{
+    tr_vec_map m;
+    for ( int i{ 0 }; i < 10; ++i )
+        m.try_emplace( i, i * 10 );
+    auto const erased{ erase_if( m, []( auto const & kv ) { return kv.first >= 5; } ) };
+    EXPECT_EQ( erased, 5 );
+    EXPECT_EQ( m.size(), 5 );
+}
+
+TEST( flat_map, tr_vector_bulk_merge )
+{
+    tr_vec_map target;
+    target.try_emplace( 1, 10 );
+    target.try_emplace( 3, 30 );
+    tr_vec_map source;
+    source.try_emplace( 2, 20 );
+    source.try_emplace( 3, 999 );
+    target.merge( source );
+    EXPECT_EQ( target.size(), 3 );
+    EXPECT_EQ( target.at( 3 ), 30 ); // existing wins
+    EXPECT_EQ( source.size(), 1 );    // duplicate stays in source
+}
+
+TEST( flat_map, tr_vector_size_type_is_uint32 )
+{
+    static_assert( std::is_same_v<tr_vec_map::size_type, std::uint32_t> );
+}
+
+TEST( flat_map, large_insert_range )
+{
+    FM m;
+    std::vector<std::pair<int, int>> src;
+    src.reserve( 1000 );
+    for ( int i{ 999 }; i >= 0; --i )
+        src.emplace_back( i, i * 10 );
+    m.insert_range( src );
+    EXPECT_EQ( m.size(), 1000 );
+    EXPECT_TRUE( std::is_sorted( m.keys().begin(), m.keys().end() ) );
+    EXPECT_EQ( m.at( 0 ), 0 );
+    EXPECT_EQ( m.at( 999 ), 9990 );
+}
+
+TEST( flat_map, large_merge_bulk )
+{
+    FM target;
+    for ( int i{ 0 }; i < 500; i += 2 )
+        target.try_emplace( i, i );
+    FM source;
+    for ( int i{ 1 }; i < 500; i += 2 )
+        source.try_emplace( i, i );
+    target.merge( source );
+    EXPECT_EQ( target.size(), 500 );
+    EXPECT_TRUE( source.empty() );
+    EXPECT_TRUE( std::is_sorted( target.keys().begin(), target.keys().end() ) );
+}
+
+// Move/copy tracking type for forwarding correctness tests
+struct tracked
+{
+    int  value{ -1 };
+    int  copies{ 0 };
+    int  moves { 0 };
+
+    tracked() = default;
+    explicit tracked( int v ) : value{ v } {}
+
+    tracked( tracked const & o ) : value{ o.value }, copies{ o.copies + 1 }, moves{ o.moves } {}
+    tracked( tracked &&      o ) noexcept : value{ o.value }, copies{ o.copies }, moves{ o.moves + 1 } { o.value = -1; }
+
+    tracked & operator=( tracked const & o ) { value = o.value; copies = o.copies + 1; moves = o.moves; return *this; }
+    tracked & operator=( tracked &&      o ) noexcept { value = o.value; copies = o.copies; moves = o.moves + 1; o.value = -1; return *this; }
+
+    bool operator< ( tracked const & o ) const noexcept { return value <  o.value; }
+    bool operator==( tracked const & o ) const noexcept { return value == o.value; }
+};
+
+TEST( flat_map, forwarding_lvalue_insert_copies_not_moves )
+{
+    // append_from with lvalue iterators: std::get<N>(forward<pair<T,T>&>(elem)) → copy
+    std::vector<std::pair<tracked, tracked>> src{
+        { tracked{ 3 }, tracked{ 30 } },
+        { tracked{ 1 }, tracked{ 10 } },
+        { tracked{ 2 }, tracked{ 20 } }
+    };
+    // Reset counters (vector emplacement may have copied/moved)
+    for ( auto & [k, v] : src ) { k.copies = k.moves = v.copies = v.moves = 0; }
+
+    flat_map<tracked, tracked> m;
+    m.insert( src.begin(), src.end() ); // lvalue iterators → append_from
+
+    EXPECT_EQ( m.size(), 3u );
+    // Source must be intact (copied, not moved)
+    for ( auto const & [k, v] : src ) {
+        EXPECT_NE( k.value, -1 ) << "key was moved from";
+        EXPECT_NE( v.value, -1 ) << "value was moved from";
+    }
+    // Each element in the map should have been copied (≥1) and never moved from source
+    for ( auto it{ m.begin() }; it != m.end(); ++it ) {
+        EXPECT_GT( it->first.copies, 0 ) << "key should have been copied";
+        EXPECT_GT( it->second.copies, 0 ) << "value should have been copied";
+    }
+}
+
+TEST( flat_map, forwarding_move_iterator_insert_moves_not_copies )
+{
+    // append_from with move iterators: std::get<N>(forward<pair<T,T>&&>(elem)) → move
+    std::vector<std::pair<tracked, tracked>> src{
+        { tracked{ 2 }, tracked{ 20 } },
+        { tracked{ 1 }, tracked{ 10 } }
+    };
+    for ( auto & [k, v] : src ) { k.copies = k.moves = v.copies = v.moves = 0; }
+
+    flat_map<tracked, tracked> m;
+    m.insert( std::make_move_iterator( src.begin() ), std::make_move_iterator( src.end() ) );
+
+    EXPECT_EQ( m.size(), 2u );
+    // Source should have been moved from
+    for ( auto const & [k, v] : src ) {
+        EXPECT_EQ( k.value, -1 ) << "key was NOT moved from";
+        EXPECT_EQ( v.value, -1 ) << "value was NOT moved from";
+    }
+    // Map elements: zero copies from source (moves only from emplace_back + possible sort moves)
+    for ( auto it{ m.begin() }; it != m.end(); ++it ) {
+        EXPECT_EQ( it->first.copies, 0 )  << "key should not have been copied from source";
+        EXPECT_EQ( it->second.copies, 0 ) << "value should not have been copied from source";
+        EXPECT_GT( it->first.moves, 0 )   << "key should have been moved";
+        EXPECT_GT( it->second.moves, 0 )  << "value should have been moved";
+    }
+}
+
+TEST( flat_map, forwarding_insert_range_lvalue_copies )
+{
+    // insert_range from lvalue range → common view → lvalue iterators → copies
+    std::vector<std::pair<tracked, tracked>> src{
+        { tracked{ 1 }, tracked{ 10 } },
+        { tracked{ 2 }, tracked{ 20 } }
+    };
+    for ( auto & [k, v] : src ) { k.copies = k.moves = v.copies = v.moves = 0; }
+
+    flat_map<tracked, tracked> m;
+    m.insert_range( src );
+
+    EXPECT_EQ( m.size(), 2u );
+    for ( auto const & [k, v] : src ) {
+        EXPECT_NE( k.value, -1 ) << "key was moved from";
+        EXPECT_NE( v.value, -1 ) << "value was moved from";
+    }
+}
+
+TEST( flat_map, forwarding_constructor_lvalue_copies )
+{
+    // Range constructor with lvalue iterators → append_from → copies
+    std::vector<std::pair<tracked, tracked>> src{
+        { tracked{ 2 }, tracked{ 20 } },
+        { tracked{ 1 }, tracked{ 10 } }
+    };
+    for ( auto & [k, v] : src ) { k.copies = k.moves = v.copies = v.moves = 0; }
+
+    flat_map<tracked, tracked> m( src.begin(), src.end() );
+
+    EXPECT_EQ( m.size(), 2u );
+    for ( auto const & [k, v] : src ) {
+        EXPECT_NE( k.value, -1 ) << "key was moved from";
+        EXPECT_NE( v.value, -1 ) << "value was moved from";
+    }
+}
+
+TEST( flat_map, forwarding_constructor_move_iterator_moves )
+{
+    // Range constructor with move iterators → append_from → moves
+    std::vector<std::pair<tracked, tracked>> src{
+        { tracked{ 2 }, tracked{ 20 } },
+        { tracked{ 1 }, tracked{ 10 } }
+    };
+    for ( auto & [k, v] : src ) { k.copies = k.moves = v.copies = v.moves = 0; }
+
+    flat_map<tracked, tracked> m( std::make_move_iterator( src.begin() ), std::make_move_iterator( src.end() ) );
+
+    EXPECT_EQ( m.size(), 2u );
+    for ( auto const & [k, v] : src ) {
+        EXPECT_EQ( k.value, -1 ) << "key was NOT moved from";
+        EXPECT_EQ( v.value, -1 ) << "value was NOT moved from";
+    }
+    for ( auto it{ m.begin() }; it != m.end(); ++it ) {
+        EXPECT_EQ( it->first.copies, 0 )  << "key should not have been copied";
+        EXPECT_EQ( it->second.copies, 0 ) << "value should not have been copied";
+    }
+}
+
+TEST( flat_map, forwarding_sorted_unique_insert_lvalue_copies )
+{
+    // insert(sorted_unique, ...) with lvalue iterators → append_from → copies
+    std::vector<std::pair<tracked, tracked>> src{
+        { tracked{ 1 }, tracked{ 10 } },
+        { tracked{ 2 }, tracked{ 20 } },
+        { tracked{ 3 }, tracked{ 30 } }
+    };
+    for ( auto & [k, v] : src ) { k.copies = k.moves = v.copies = v.moves = 0; }
+
+    flat_map<tracked, tracked> m;
+    m.insert( sorted_unique, src.begin(), src.end() );
+
+    EXPECT_EQ( m.size(), 3u );
+    for ( auto const & [k, v] : src ) {
+        EXPECT_NE( k.value, -1 ) << "key was moved from";
+        EXPECT_NE( v.value, -1 ) << "value was moved from";
+    }
+}
+
+TEST( flat_map, forwarding_merge_rvalue_moves )
+{
+    // merge(flat_map&&) → append_move_containers → moves
+    flat_map<tracked, tracked> target;
+    target.insert( { tracked{ 1 }, tracked{ 10 } } );
+    target.insert( { tracked{ 3 }, tracked{ 30 } } );
+
+    flat_map<tracked, tracked> source;
+    source.insert( { tracked{ 2 }, tracked{ 20 } } );
+    source.insert( { tracked{ 4 }, tracked{ 40 } } );
+
+    // Reset counters after initial insertions
+    for ( auto it{ target.begin() }; it != target.end(); ++it ) {
+        const_cast<tracked &>( it->first ).copies = const_cast<tracked &>( it->first ).moves = 0;
+        it->second.copies = it->second.moves = 0;
+    }
+    for ( auto it{ source.begin() }; it != source.end(); ++it ) {
+        const_cast<tracked &>( it->first ).copies = const_cast<tracked &>( it->first ).moves = 0;
+        it->second.copies = it->second.moves = 0;
+    }
+
+    target.merge( std::move( source ) );
+
+    EXPECT_EQ( target.size(), 4u );
+    EXPECT_TRUE( source.empty() );
+    // The merged elements (2,4) should have been moved, not copied
+    EXPECT_EQ( target.find( tracked{ 2 } )->first.copies,  0 ) << "merged key should not have been copied";
+    EXPECT_EQ( target.find( tracked{ 2 } )->second.copies, 0 ) << "merged value should not have been copied";
+    EXPECT_EQ( target.find( tracked{ 4 } )->first.copies,  0 ) << "merged key should not have been copied";
+    EXPECT_EQ( target.find( tracked{ 4 } )->second.copies, 0 ) << "merged value should not have been copied";
+}
+
+//------------------------------------------------------------------------------
+} // namespace psi::vm
+//------------------------------------------------------------------------------


### PR DESCRIPTION
Added a full `std::flat_map` (P0429R9) polyfill with separate key/value containers, plus extensions (`reserve`, `shrink_to_fit`, `merge`, `insert_range(sorted_unique_t, ...)`). Includes 100 unit tests covering the complete interface.

### Changes

**New: `include/psi/vm/containers/flat_map.hpp`** (+867)

Complete `std::flat_map` implementation built on a `detail::paired_storage<KC, MC>` base class that synchronises dual-container operations (insert, erase, append, clear, reserve, replace, swap). `flat_map` privately inherits it — the base doubles as the standard-required `containers` type returned by `extract()`.

Key design decisions:
- Bulk append delegates to `append_range` + `std::views::elements<0/1>` / `std::views::as_rvalue` with exception-safe rollback
- `ranges::sort` / `inplace_merge` / `unique` with `key_proj()` projection instead of ad-hoc comparator wrappers
- Per-container `if constexpr` dispatch in `truncate_to` (KC and MC may have different capabilities)
- Conditional `noexcept` on `extract()` and `replace()`; unconditional on `shrink_to_fit()`, `clear()`, erase ops
- Zero `-Wsign-conversion` warnings (explicit `static_cast` at `size_type`↔`difference_type` boundaries)
- `[[noreturn, gnu::cold]]` `throw_out_of_range` helper

Extensions beyond C++23 `std::flat_map`:
- `reserve(n)`, `shrink_to_fit()` — bulk pre-allocation / compaction
- `merge(source)` (lvalue & rvalue) — `std::map`-style element transfer
- `insert_range(sorted_unique_t, R&&)` — sorted bulk range insert

**New: `test/flat_map.cpp`** (+1322)

100 tests covering:
- Construction (default, iterators, sorted_unique, ranges, init-lists, copy, move)
- Element access (`operator[]`, `at`, transparent overloads)
- Lookup (`find`, `count`, `contains`, `lower_bound`, `upper_bound`, `equal_range`)
- Modifiers (`insert`, `insert_range`, `emplace`, `try_emplace`, `insert_or_assign`, `erase`, `erase_if`)
- `merge` (lvalue O(N+M) scan, rvalue bulk move, self-merge, empty)
- `extract` / `replace` round-trip
- Observers (`key_comp`, `value_comp`, `keys`, `values`)
- Comparison (`==`, `<=>`)
- Deduction guides (containers, iterators, ranges, init-lists)
- Forwarding correctness (7 tests with `tracked` type verifying exact copy/move counts for lvalue, rvalue, and move_iterator ranges)

**Moved: `make_trivially_copyable_predicate`** `b+tree.hpp` → `abi.hpp`

Shared utility used by both `b+tree` and `flat_map` for passing non-trivially-copyable predicates to algorithms that take them by value.

**`vector_impl.hpp`**: Fix `resize()` to forward the initializer argument (was taking `auto const`, now templated with perfect forwarding).

** Removed the gtest_discover_tests logic from the test CMakeLists as it was making it difficult to debug crashes on GH CI runs.