### PR TITLE
Feature/small vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Cross-platform abstractions over OS virtual memory and memory-mapped I/O:
 
 | Container | Description |
 |-----------|-------------|
+| `small_vector<T, N>` | **Small Vector** — inline (stack) buffer with heap spill. Three layout modes: *compact* (MSB tag, trivially relocatable, `[[clang::trivial_abi]]`), *compact_lsb* (LSB tag, optimal LE addressing), *pointer_based* (LLVM/Boost style, type-erasable via `small_vector_base<T>`). Configurable `geometric_growth` factor, `sz_t`, and alignment |
 | `tr_vector<T>` | **Trivially Relocatable Vector** — exploits trivial relocatability for move/realloc without element-wise copy |
 | `vm_vector<T>` | **VM-backed Vector** — persistent storage via memory-mapped files or shared memory, with configurable headers and allocation granularity |
 | `fc_vector<T, N>` | **Fixed Capacity Vector** — inline (stack) storage with compile-time capacity bound (`inplace_vector`-like) |

--- a/include/psi/vm/containers/fc_vector.hpp
+++ b/include/psi/vm/containers/fc_vector.hpp
@@ -30,6 +30,7 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include <psi/vm/containers/noninitialized_array.hpp>
 #include <psi/vm/containers/vector_impl.hpp>
 
 #include <boost/assert.hpp>
@@ -40,15 +41,6 @@
 namespace psi::vm
 {
 //------------------------------------------------------------------------------
-
-template <typename T, std::uint32_t size>
-union [[ clang::trivial_abi ]] noninitialized_array // utility for easier debugging: no need for special 'visualizers' over type-erased byte arrays
-{
-    constexpr  noninitialized_array() noexcept {}
-    constexpr ~noninitialized_array() noexcept {}
-
-    T data[ size ];
-}; // noninitialized_array
 
 struct assert_on_overflow {
     [[ noreturn ]] static void operator()() noexcept {

--- a/include/psi/vm/containers/noninitialized_array.hpp
+++ b/include/psi/vm/containers/noninitialized_array.hpp
@@ -1,0 +1,37 @@
+////////////////////////////////////////////////////////////////////////////////
+/// Utility union for easier debugging: no need for special 'visualizers' over
+/// type-erased byte arrays — contained values are directly visible in the
+/// debugger.
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Copyright (c) Domagoj Saric.
+///
+/// Use, modification and distribution is subject to the
+/// Boost Software License, Version 1.0.
+/// (See accompanying file LICENSE_1_0.txt or copy at
+/// http://www.boost.org/LICENSE_1_0.txt)
+///
+/// For more information, see http://www.boost.org
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <cstdint>
+//------------------------------------------------------------------------------
+namespace psi::vm
+{
+//------------------------------------------------------------------------------
+
+template <typename T, std::uint32_t size>
+union [[ clang::trivial_abi ]] noninitialized_array
+{
+    constexpr  noninitialized_array() noexcept {}
+    constexpr ~noninitialized_array() noexcept {}
+
+    T data[ size ];
+}; // noninitialized_array
+
+//------------------------------------------------------------------------------
+} // namespace psi::vm
+//------------------------------------------------------------------------------

--- a/include/psi/vm/containers/small_vector.hpp
+++ b/include/psi/vm/containers/small_vector.hpp
@@ -1,0 +1,918 @@
+////////////////////////////////////////////////////////////////////////////////
+/// Small vector — inline (stack) buffer with heap spill
+///
+/// Three layout modes selectable via NTTP options:
+///  - compact (default): union-based, MSB-of-size flag, trivially relocatable,
+///    [[clang::trivial_abi]]. No self-referential pointer.
+///  - compact_lsb: like compact but size_ comes first (before the union) and
+///    LSB of size_ is the heap flag. On LE systems the flag is in byte 0 of the
+///    struct for optimal addressing (test byte [ptr], 1).
+///  - pointer_based: Boost/LLVM SmallVector style — type-erasable across N
+///    values via small_vector_base<T>, trivial data() getter, but NOT trivially
+///    relocatable (data_ points to inline buffer when small).
+///
+/// All layouts require is_trivially_moveable<T> (memcpy/realloc for moves).
+/// Built on vector_impl CRTP base, reuses crt_aligned_allocator for heap path.
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Copyright (c) Domagoj Saric.
+///
+/// Use, modification and distribution is subject to the
+/// Boost Software License, Version 1.0.
+/// (See accompanying file LICENSE_1_0.txt or copy at
+/// http://www.boost.org/LICENSE_1_0.txt)
+///
+/// For more information, see http://www.boost.org
+///
+////////////////////////////////////////////////////////////////////////////////
+//------------------------------------------------------------------------------
+#pragma once
+
+#include <psi/vm/containers/noninitialized_array.hpp>
+#include <psi/vm/containers/tr_vector.hpp> // crt_aligned_allocator, vector_impl
+
+#include <boost/assert.hpp>
+
+#include <climits>
+#include <cstring>
+#include <utility>
+//------------------------------------------------------------------------------
+namespace psi::vm
+{
+//------------------------------------------------------------------------------
+
+enum class small_vector_layout : std::uint8_t {
+    compact_lsb,   // union-based, size-first with LSB flag, trivially relocatable
+    compact,       // union-based, MSB-of-size flag, trivially relocatable
+    pointer_based  // LLVM/Boost style, type-erasable
+};
+
+struct small_vector_options
+{
+    std::uint8_t        alignment{ 0 };
+    geometric_growth    growth   { .num = 5, .den = 4 }; // 1.25x default (conservative for small vectors)
+    small_vector_layout layout   { /*first as default*/ };
+}; // struct small_vector_options
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Forward declarations
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, std::uint32_t N, typename sz_t = std::size_t, small_vector_options options = {}>
+class small_vector;
+
+// pointer_based layout base (N-independent)
+template <typename T, typename sz_t, small_vector_options options>
+requires( options.layout == small_vector_layout::pointer_based && is_trivially_moveable<T> )
+class small_vector_base;
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Layout A: Compact (union-based) — trivially relocatable
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, std::uint32_t N, typename sz_t, small_vector_options options>
+requires( options.layout == small_vector_layout::compact && is_trivially_moveable<T> )
+class [[ nodiscard, clang::trivial_abi ]] small_vector<T, N, sz_t, options>
+    :
+    public vector_impl<small_vector<T, N, sz_t, options>, T, sz_t>
+{
+    static_assert( N > 0, "Use tr_vector for N=0" );
+
+public:
+    static std::uint8_t constexpr alignment{ options.alignment ? options.alignment : std::uint8_t{ alignof( std::conditional_t<complete<T>, T, std::max_align_t> ) } };
+
+    static bool constexpr storage_zero_initialized{ false };
+
+    using size_type      = sz_t;
+    using value_type     = T;
+    using allocator_type = crt_aligned_allocator<T, sz_t, alignment>;
+
+private:
+    using al   = allocator_type;
+    using base = vector_impl<small_vector, T, sz_t>;
+
+    static sz_t constexpr heap_flag   { sz_t{ 1 } << ( sizeof( sz_t ) * CHAR_BIT - 1 ) };
+    static sz_t constexpr size_mask   { ~heap_flag };
+    static sz_t constexpr max_size_val{ size_mask  };
+
+    // Named union with explicit ctor/dtor so that the noninitialized_array
+    // variant member does not delete the enclosing type's default constructor.
+    union data_t {
+        constexpr  data_t() noexcept : buffer_{} {}
+        constexpr ~data_t() noexcept {}
+
+        struct {
+            T * __restrict data_;
+            sz_t           capacity_;
+        } heap_;
+        noninitialized_array<T, N> buffer_;
+    };
+
+    [[ nodiscard, gnu::pure ]] bool is_heap() const noexcept { return ( size_ & heap_flag ) != 0; }
+
+    void set_inline_size( sz_t const sz ) noexcept
+    {
+        BOOST_ASSUME( sz <= N );
+        BOOST_ASSUME( !( sz & heap_flag ) );
+        size_ = sz;
+    }
+    void set_heap_state( T * __restrict const p, sz_t const cap, sz_t const sz ) noexcept
+    {
+        BOOST_ASSUME( !( sz & heap_flag ) );
+        storage_.heap_.data_     = p;
+        storage_.heap_.capacity_ = cap;
+        size_                    = sz | heap_flag;
+    }
+    void set_size_preserving_flag( sz_t const sz ) noexcept
+    {
+        BOOST_ASSUME( !( sz & heap_flag ) );
+        size_ = sz | ( size_ & heap_flag );
+    }
+
+public:
+    using base::base;
+
+    constexpr small_vector() noexcept : size_{ 0 } {}
+
+    constexpr small_vector( small_vector const & other ) : base{}
+    {
+        auto const sz{ other.size() };
+        auto const dst{ storage_init( sz ) };
+        try { std::uninitialized_copy_n( other.data(), sz, dst ); }
+        catch( ... ) { storage_free(); throw; }
+    }
+
+    constexpr small_vector( small_vector && other ) noexcept : base{}
+    {
+        auto const sz{ other.size() };
+        if ( other.is_heap() )
+        {
+            set_heap_state( other.storage_.heap_.data_, other.storage_.heap_.capacity_, sz );
+        }
+        else
+        {
+            std::memcpy( static_cast<void *>( storage_.buffer_.data ), other.storage_.buffer_.data, sz * sizeof( T ) );
+            set_inline_size( sz );
+        }
+        other.set_inline_size( 0 );
+    }
+
+    constexpr small_vector & operator=( small_vector const & other )
+    {
+        return ( *this = small_vector( other ) );
+    }
+
+    constexpr small_vector & operator=( small_vector && other ) noexcept
+    {
+        this->clear();
+        if ( is_heap() )
+            al::deallocate( storage_.heap_.data_, storage_.heap_.capacity_ );
+        auto const sz{ other.size() };
+        if ( other.is_heap() )
+        {
+            set_heap_state( other.storage_.heap_.data_, other.storage_.heap_.capacity_, sz );
+        }
+        else
+        {
+            std::memcpy( static_cast<void *>( storage_.buffer_.data ), other.storage_.buffer_.data, sz * sizeof( T ) );
+            set_inline_size( sz );
+        }
+        other.set_inline_size( 0 );
+        return *this;
+    }
+
+    constexpr small_vector & operator=( std::initializer_list<value_type> const data ) { this->assign( data ); return *this; }
+
+    constexpr ~small_vector() noexcept
+    {
+        std::destroy_n( data(), size() );
+        if ( is_heap() )
+            al::deallocate( storage_.heap_.data_, storage_.heap_.capacity_ );
+    }
+
+    [[ nodiscard, gnu::pure ]] sz_t size() const noexcept
+    {
+        auto const sz{ size_ & size_mask };
+        BOOST_ASSUME( sz <= max_size_val );
+        return sz;
+    }
+    [[ nodiscard, gnu::pure ]] sz_t capacity() const noexcept
+    {
+        return is_heap() ? storage_.heap_.capacity_ : sz_t{ N };
+    }
+
+    [[ nodiscard, gnu::pure ]] value_type       * data()       noexcept { return is_heap() ? storage_.heap_.data_ : storage_.buffer_.data; }
+    [[ nodiscard, gnu::pure ]] value_type const * data() const noexcept { return is_heap() ? storage_.heap_.data_ : storage_.buffer_.data; }
+
+    void reserve( size_type const new_capacity )
+    {
+        if ( new_capacity > capacity() )
+            grow_heap( new_capacity );
+    }
+
+private: friend base;
+    [[ gnu::cold ]]
+#ifdef _MSC_VER
+    __declspec( noalias )
+#endif
+    constexpr value_type * storage_init( size_type const initial_size )
+    {
+        if ( initial_size > N )
+        {
+            auto const p{ al::allocate( initial_size ) };
+            set_heap_state( p, initial_size, initial_size );
+            return p;
+        }
+        set_inline_size( initial_size );
+        return storage_.buffer_.data;
+    }
+
+    [[ gnu::returns_nonnull ]]
+    constexpr value_type * storage_grow_to( size_type const target_size )
+    {
+        auto const current_cap{ capacity() };
+        BOOST_ASSUME( target_size >= size() );
+        if ( target_size > current_cap ) [[ unlikely ]]
+        {
+            grow_heap( options.growth( target_size, current_cap ) );
+        }
+        set_size_preserving_flag( target_size );
+        return data();
+    }
+
+    constexpr value_type * storage_shrink_to( size_type const target_size ) noexcept
+    {
+        BOOST_ASSUME( target_size <= size() );
+        if ( is_heap() )
+        {
+            storage_.heap_.data_     = al::shrink_to( storage_.heap_.data_, size(), target_size );
+            storage_.heap_.capacity_ = target_size;
+            BOOST_ASSUME( storage_.heap_.data_ || !target_size );
+        }
+        set_size_preserving_flag( target_size );
+        return data();
+    }
+
+    constexpr void storage_shrink_size_to( size_type const target_size ) noexcept
+    {
+        BOOST_ASSUME( size() >= target_size );
+        set_size_preserving_flag( target_size );
+    }
+
+    void storage_dec_size() noexcept
+    {
+        BOOST_ASSUME( size() >= 1 );
+        --size_;
+    }
+    void storage_inc_size() noexcept
+    {
+        BOOST_ASSUME( size() < capacity() );
+        ++size_;
+    }
+
+#ifdef _MSC_VER
+    bool storage_try_expand_capacity( size_type const target_capacity ) noexcept
+    requires( alignment <= detail::guaranteed_alignment )
+    {
+        if ( !is_heap() )
+            return false;
+        namespace bc = boost::container;
+        auto recv_size{ target_capacity };
+        auto reuse    { storage_.heap_.data_ };
+        auto const result{ al::allocation_command(
+            bc::expand_fwd | bc::nothrow_allocation,
+            target_capacity, recv_size, reuse
+        ) };
+        if ( result )
+        {
+            storage_.heap_.capacity_ = recv_size;
+            return true;
+        }
+        return false;
+    }
+#endif
+
+    void storage_free() noexcept
+    {
+        if ( is_heap() )
+            al::deallocate( storage_.heap_.data_, storage_.heap_.capacity_ );
+        set_inline_size( 0 );
+    }
+
+private:
+    [[ gnu::cold, gnu::noinline, clang::preserve_most ]]
+    void grow_heap( size_type const new_capacity )
+    {
+        BOOST_ASSUME( new_capacity > capacity() );
+        if ( is_heap() )
+        {
+            storage_.heap_.data_     = al::grow_to( storage_.heap_.data_, storage_.heap_.capacity_, new_capacity );
+            storage_.heap_.capacity_ = new_capacity;
+        }
+        else
+        {
+            auto const sz{ size() };
+            auto const p { al::allocate( new_capacity ) };
+            std::memcpy( static_cast<void *>( p ), storage_.buffer_.data, sz * sizeof( T ) );
+            set_heap_state( p, new_capacity, sz );
+        }
+    }
+
+private:
+    data_t storage_;
+    sz_t   size_; // MSB = heap flag
+}; // class small_vector (compact)
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Layout B: Pointer-based — type-erasable
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename sz_t, small_vector_options options>
+requires( options.layout == small_vector_layout::pointer_based && is_trivially_moveable<T> )
+class [[ nodiscard ]] small_vector_base
+    :
+    public vector_impl<small_vector_base<T, sz_t, options>, T, sz_t>
+{
+public:
+    static std::uint8_t constexpr alignment{ options.alignment ? options.alignment : std::uint8_t{ alignof( std::conditional_t<complete<T>, T, std::max_align_t> ) } };
+
+    static bool constexpr storage_zero_initialized{ false };
+
+    using size_type      = sz_t;
+    using value_type     = T;
+    using allocator_type = crt_aligned_allocator<T, sz_t, alignment>;
+
+private:
+    using al   = allocator_type;
+    using base = vector_impl<small_vector_base, T, sz_t>;
+
+protected:
+    [[ nodiscard, gnu::pure ]] T * first_el() noexcept
+    {
+        auto const raw{ reinterpret_cast<char *>( this ) + sizeof( small_vector_base ) };
+        return reinterpret_cast<T *>( ( reinterpret_cast<std::uintptr_t>( raw ) + alignof( T ) - 1 ) & ~( alignof( T ) - 1 ) );
+    }
+    [[ nodiscard, gnu::pure ]] T const * first_el() const noexcept { return const_cast<small_vector_base *>( this )->first_el(); }
+
+    void reset_to_small( sz_t const inline_cap ) noexcept
+    {
+        data_     = first_el();
+        size_     = 0;
+        capacity_ = inline_cap;
+    }
+
+public:
+    [[ nodiscard, gnu::pure ]] bool is_small() const noexcept { return data_ == first_el(); }
+
+    [[ nodiscard, gnu::pure ]] sz_t size    () const noexcept { return size_;     }
+    [[ nodiscard, gnu::pure ]] sz_t capacity() const noexcept { return capacity_; }
+
+    [[ nodiscard, gnu::pure ]] value_type       * data()       noexcept { return data_; }
+    [[ nodiscard, gnu::pure ]] value_type const * data() const noexcept { return data_; }
+
+    void reserve( size_type const new_capacity )
+    {
+        if ( new_capacity > capacity_ )
+            grow_heap( new_capacity );
+    }
+
+private: friend base;
+    template <typename, std::uint32_t, typename, small_vector_options> friend class small_vector;
+
+    [[ gnu::cold ]]
+#ifdef _MSC_VER
+    __declspec( noalias )
+#endif
+    constexpr value_type * storage_init( size_type const initial_size )
+    {
+        if ( initial_size > capacity_ )
+        {
+            data_     = al::allocate( initial_size );
+            size_     = initial_size;
+            capacity_ = initial_size;
+            return data_;
+        }
+        size_ = initial_size;
+        return data_;
+    }
+
+    constexpr value_type * storage_grow_to( size_type const target_size )
+    {
+        BOOST_ASSUME( target_size >= size_ );
+        if ( target_size > capacity_ ) [[ unlikely ]]
+        {
+            grow_heap( options.growth( target_size, capacity_ ) );
+        }
+        size_ = target_size;
+        return data_;
+    }
+
+    constexpr value_type * storage_shrink_to( size_type const target_size ) noexcept
+    {
+        BOOST_ASSUME( target_size <= size_ );
+        if ( !is_small() )
+        {
+            data_     = al::shrink_to( data_, size_, target_size );
+            capacity_ = target_size;
+            BOOST_ASSUME( data_ || !target_size );
+        }
+        size_ = target_size;
+        return data_;
+    }
+
+    constexpr void storage_shrink_size_to( size_type const target_size ) noexcept
+    {
+        BOOST_ASSUME( size_ >= target_size );
+        size_ = target_size;
+    }
+
+    void storage_dec_size() noexcept { BOOST_ASSUME( size_ >= 1 ); --size_; }
+    void storage_inc_size() noexcept { BOOST_ASSUME( size_ < capacity_ ); ++size_; }
+
+#ifdef _MSC_VER
+    bool storage_try_expand_capacity( size_type const target_capacity ) noexcept
+    requires( alignment <= detail::guaranteed_alignment )
+    {
+        if ( is_small() )
+            return false;
+        namespace bc = boost::container;
+        auto recv_size{ target_capacity };
+        auto reuse    { data_ };
+        auto const result{ al::allocation_command(
+            bc::expand_fwd | bc::nothrow_allocation,
+            target_capacity, recv_size, reuse
+        ) };
+        if ( result )
+        {
+            capacity_ = recv_size;
+            return true;
+        }
+        return false;
+    }
+#endif
+
+    void storage_free() noexcept
+    {
+        if ( !is_small() )
+            al::deallocate( data_, capacity_ );
+    }
+
+private:
+    [[ gnu::cold, gnu::noinline, clang::preserve_most ]]
+    void grow_heap( size_type const new_capacity )
+    {
+        BOOST_ASSUME( new_capacity > capacity_ );
+        if ( !is_small() )
+        {
+            data_     = al::grow_to( data_, capacity_, new_capacity );
+            capacity_ = new_capacity;
+        }
+        else
+        {
+            auto const p{ al::allocate( new_capacity ) };
+            std::memcpy( static_cast<void *>( p ), data_, size_ * sizeof( T ) );
+            data_     = p;
+            capacity_ = new_capacity;
+        }
+    }
+
+protected:
+    T * __restrict data_;
+    sz_t           size_;
+    sz_t           capacity_;
+}; // class small_vector_base
+
+
+template <typename T, std::uint32_t N, typename sz_t, small_vector_options options>
+requires( options.layout == small_vector_layout::pointer_based && is_trivially_moveable<T> )
+class [[ nodiscard ]] small_vector<T, N, sz_t, options>
+    :
+    public small_vector_base<T, sz_t, options>
+{
+    static_assert( N > 0, "Use tr_vector for N=0" );
+
+    using ptr_base = small_vector_base<T, sz_t, options>;
+
+public:
+    using size_type  = sz_t;
+    using value_type = T;
+
+    constexpr small_vector() noexcept { ptr_base::reset_to_small( N ); }
+
+    constexpr small_vector( small_vector const & other ) : ptr_base{}
+    {
+        ptr_base::reset_to_small( N );
+        auto const sz{ other.size() };
+        auto const dst{ this->storage_init( sz ) };
+        try { std::uninitialized_copy_n( other.data(), sz, dst ); }
+        catch( ... ) { this->storage_free(); ptr_base::reset_to_small( N ); throw; }
+    }
+
+    constexpr small_vector( small_vector && other ) noexcept : ptr_base{}
+    {
+        auto const sz{ other.size() };
+        if ( other.is_small() )
+        {
+            ptr_base::reset_to_small( N );
+            std::memcpy( static_cast<void *>( buffer_.data ), other.data(), sz * sizeof( T ) );
+            this->size_ = sz;
+        }
+        else
+        {
+            this->data_     = other.data_;
+            this->size_     = sz;
+            this->capacity_ = other.capacity_;
+        }
+        other.reset_to_small( N );
+    }
+
+    constexpr small_vector & operator=( small_vector const & other )
+    {
+        return ( *this = small_vector( other ) );
+    }
+
+    constexpr small_vector & operator=( small_vector && other ) noexcept
+    {
+        this->clear();
+        if ( !this->is_small() )
+            ptr_base::allocator_type::deallocate( this->data_, this->capacity_ );
+        auto const sz{ other.size() };
+        if ( other.is_small() )
+        {
+            ptr_base::reset_to_small( N );
+            std::memcpy( static_cast<void *>( buffer_.data ), other.data(), sz * sizeof( T ) );
+            this->size_ = sz;
+        }
+        else
+        {
+            this->data_     = other.data_;
+            this->size_     = sz;
+            this->capacity_ = other.capacity_;
+        }
+        other.reset_to_small( N );
+        return *this;
+    }
+
+    constexpr small_vector & operator=( std::initializer_list<value_type> const data ) { this->assign( data ); return *this; }
+
+    constexpr ~small_vector() noexcept
+    {
+        std::destroy_n( this->data(), this->size() );
+        this->storage_free();
+    }
+
+    constexpr explicit small_vector( size_type const initial_size ) : small_vector( initial_size, default_init ) {}
+    constexpr small_vector( size_type const initial_size, no_init_t ) : ptr_base{}
+    {
+        ptr_base::reset_to_small( N );
+        this->storage_init( initial_size );
+    }
+    constexpr small_vector( size_type const initial_size, default_init_t ) : ptr_base{}
+    {
+        ptr_base::reset_to_small( N );
+        auto const dst{ this->storage_init( initial_size ) };
+        std::uninitialized_default_construct_n( dst, initial_size );
+    }
+    constexpr small_vector( size_type const initial_size, value_init_t ) : ptr_base{}
+    {
+        ptr_base::reset_to_small( N );
+        auto const dst{ this->storage_init( initial_size ) };
+        std::uninitialized_value_construct_n( dst, initial_size );
+    }
+    constexpr small_vector( size_type const count, value_type const & value ) : ptr_base{}
+    {
+        ptr_base::reset_to_small( N );
+        auto const dst{ this->storage_init( count ) };
+        std::uninitialized_fill_n( dst, count, value );
+    }
+    template <std::input_iterator It>
+    constexpr small_vector( It const first, It const last ) : ptr_base{}
+    {
+        ptr_base::reset_to_small( N );
+        if constexpr ( std::random_access_iterator<It> )
+        {
+            auto const sz{ static_cast<size_type>( std::distance( first, last ) ) };
+            auto const dst{ this->storage_init( sz ) };
+            std::uninitialized_copy_n( first, sz, dst );
+        }
+        else
+        {
+            this->storage_init( 0 );
+            std::copy( first, last, std::back_inserter( *this ) );
+        }
+    }
+    constexpr small_vector( std::initializer_list<value_type> const init ) : ptr_base{}
+    {
+        ptr_base::reset_to_small( N );
+        auto const sz{ static_cast<size_type>( init.size() ) };
+        auto const dst{ this->storage_init( sz ) };
+        std::uninitialized_copy_n( init.begin(), sz, dst );
+    }
+
+private:
+    noninitialized_array<T, N> buffer_;
+}; // class small_vector (pointer_based)
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Layout C: Compact LSB (size-first, LSB flag) — trivially relocatable
+//
+// Like compact, but size_ comes first (before the union) and the LSB of size_
+// is the heap discriminant. On little-endian, this places the flag in byte 0
+// of the struct for optimal addressing (test byte [ptr], 1).
+// size() = size_ >> 1, is_heap() = size_ & 1.
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, std::uint32_t N, typename sz_t, small_vector_options options>
+requires( options.layout == small_vector_layout::compact_lsb && is_trivially_moveable<T> )
+class [[ nodiscard, clang::trivial_abi ]] small_vector<T, N, sz_t, options>
+    :
+    public vector_impl<small_vector<T, N, sz_t, options>, T, sz_t>
+{
+    static_assert( N > 0, "Use tr_vector for N=0" );
+
+public:
+    static std::uint8_t constexpr alignment{ options.alignment ? options.alignment : std::uint8_t{ alignof( std::conditional_t<complete<T>, T, std::max_align_t> ) } };
+
+    static bool constexpr storage_zero_initialized{ false };
+
+    using size_type      = sz_t;
+    using value_type     = T;
+    using allocator_type = crt_aligned_allocator<T, sz_t, alignment>;
+
+private:
+    using al   = allocator_type;
+    using base = vector_impl<small_vector, T, sz_t>;
+
+    static sz_t constexpr max_size_val{ std::numeric_limits<sz_t>::max() >> 1 };
+
+    union data_t {
+        constexpr  data_t() noexcept : buffer_{} {}
+        constexpr ~data_t() noexcept {}
+
+        struct {
+            T * __restrict data_;
+            sz_t           capacity_;
+        } heap_;
+        noninitialized_array<T, N> buffer_;
+    };
+
+    [[ nodiscard, gnu::pure ]] bool is_heap() const noexcept { return ( size_ & 1 ) != 0; }
+
+    void set_inline_size( sz_t const sz ) noexcept
+    {
+        BOOST_ASSUME( sz <= N );
+        size_ = sz << 1; // LSB = 0 → inline
+    }
+    void set_heap_state( T * __restrict const p, sz_t const cap, sz_t const sz ) noexcept
+    {
+        BOOST_ASSUME( sz <= max_size_val );
+        storage_.heap_.data_     = p;
+        storage_.heap_.capacity_ = cap;
+        size_                    = ( sz << 1 ) | 1; // LSB = 1 → heap
+    }
+    void set_size_preserving_flag( sz_t const sz ) noexcept
+    {
+        BOOST_ASSUME( sz <= max_size_val );
+        size_ = ( sz << 1 ) | ( size_ & 1 );
+    }
+
+public:
+    using base::base;
+
+    constexpr small_vector() noexcept : size_{ 0 } {}
+
+    constexpr small_vector( small_vector const & other ) : base{}
+    {
+        auto const sz{ other.size() };
+        auto const dst{ storage_init( sz ) };
+        try { std::uninitialized_copy_n( other.data(), sz, dst ); }
+        catch( ... ) { storage_free(); throw; }
+    }
+
+    constexpr small_vector( small_vector && other ) noexcept : base{}
+    {
+        auto const sz{ other.size() };
+        if ( other.is_heap() )
+        {
+            set_heap_state( other.storage_.heap_.data_, other.storage_.heap_.capacity_, sz );
+        }
+        else
+        {
+            std::memcpy( static_cast<void *>( storage_.buffer_.data ), other.storage_.buffer_.data, sz * sizeof( T ) );
+            set_inline_size( sz );
+        }
+        other.set_inline_size( 0 );
+    }
+
+    constexpr small_vector & operator=( small_vector const & other )
+    {
+        return ( *this = small_vector( other ) );
+    }
+
+    constexpr small_vector & operator=( small_vector && other ) noexcept
+    {
+        this->clear();
+        if ( is_heap() )
+            al::deallocate( storage_.heap_.data_, storage_.heap_.capacity_ );
+        auto const sz{ other.size() };
+        if ( other.is_heap() )
+        {
+            set_heap_state( other.storage_.heap_.data_, other.storage_.heap_.capacity_, sz );
+        }
+        else
+        {
+            std::memcpy( static_cast<void *>( storage_.buffer_.data ), other.storage_.buffer_.data, sz * sizeof( T ) );
+            set_inline_size( sz );
+        }
+        other.set_inline_size( 0 );
+        return *this;
+    }
+
+    constexpr small_vector & operator=( std::initializer_list<value_type> const data ) { this->assign( data ); return *this; }
+
+    constexpr ~small_vector() noexcept
+    {
+        std::destroy_n( data(), size() );
+        if ( is_heap() )
+            al::deallocate( storage_.heap_.data_, storage_.heap_.capacity_ );
+    }
+
+    [[ nodiscard, gnu::pure ]] sz_t size() const noexcept
+    {
+        auto const sz{ size_ >> 1 };
+        BOOST_ASSUME( sz <= max_size_val );
+        return sz;
+    }
+    [[ nodiscard, gnu::pure ]] sz_t capacity() const noexcept
+    {
+        return is_heap() ? storage_.heap_.capacity_ : sz_t{ N };
+    }
+
+    [[ nodiscard, gnu::pure ]] value_type       * data()       noexcept { return is_heap() ? storage_.heap_.data_ : storage_.buffer_.data; }
+    [[ nodiscard, gnu::pure ]] value_type const * data() const noexcept { return is_heap() ? storage_.heap_.data_ : storage_.buffer_.data; }
+
+    void reserve( size_type const new_capacity )
+    {
+        if ( new_capacity > capacity() )
+            grow_heap( new_capacity );
+    }
+
+private: friend base;
+    [[ gnu::cold ]]
+#ifdef _MSC_VER
+    __declspec( noalias )
+#endif
+    constexpr value_type * storage_init( size_type const initial_size )
+    {
+        if ( initial_size > N )
+        {
+            auto const p{ al::allocate( initial_size ) };
+            set_heap_state( p, initial_size, initial_size );
+            return p;
+        }
+        set_inline_size( initial_size );
+        return storage_.buffer_.data;
+    }
+
+    [[ gnu::returns_nonnull ]]
+    constexpr value_type * storage_grow_to( size_type const target_size )
+    {
+        auto const current_cap{ capacity() };
+        BOOST_ASSUME( target_size >= size() );
+        if ( target_size > current_cap ) [[ unlikely ]]
+        {
+            grow_heap( options.growth( target_size, current_cap ) );
+        }
+        set_size_preserving_flag( target_size );
+        return data();
+    }
+
+    constexpr value_type * storage_shrink_to( size_type const target_size ) noexcept
+    {
+        BOOST_ASSUME( target_size <= size() );
+        if ( is_heap() )
+        {
+            storage_.heap_.data_     = al::shrink_to( storage_.heap_.data_, size(), target_size );
+            storage_.heap_.capacity_ = target_size;
+            BOOST_ASSUME( storage_.heap_.data_ || !target_size );
+        }
+        set_size_preserving_flag( target_size );
+        return data();
+    }
+
+    constexpr void storage_shrink_size_to( size_type const target_size ) noexcept
+    {
+        BOOST_ASSUME( size() >= target_size );
+        set_size_preserving_flag( target_size );
+    }
+
+    void storage_dec_size() noexcept
+    {
+        BOOST_ASSUME( size() >= 1 );
+        size_ -= 2; // size is stored << 1, so decrement by 2
+    }
+    void storage_inc_size() noexcept
+    {
+        BOOST_ASSUME( size() < capacity() );
+        size_ += 2; // size is stored << 1, so increment by 2
+    }
+
+#ifdef _MSC_VER
+    bool storage_try_expand_capacity( size_type const target_capacity ) noexcept
+    requires( alignment <= detail::guaranteed_alignment )
+    {
+        if ( !is_heap() )
+            return false;
+        namespace bc = boost::container;
+        auto recv_size{ target_capacity };
+        auto reuse    { storage_.heap_.data_ };
+        auto const result{ al::allocation_command(
+            bc::expand_fwd | bc::nothrow_allocation,
+            target_capacity, recv_size, reuse
+        ) };
+        if ( result )
+        {
+            storage_.heap_.capacity_ = recv_size;
+            return true;
+        }
+        return false;
+    }
+#endif
+
+    void storage_free() noexcept
+    {
+        if ( is_heap() )
+            al::deallocate( storage_.heap_.data_, storage_.heap_.capacity_ );
+        set_inline_size( 0 );
+    }
+
+private:
+    [[ gnu::cold, gnu::noinline, clang::preserve_most ]]
+    void grow_heap( size_type const new_capacity )
+    {
+        BOOST_ASSUME( new_capacity > capacity() );
+        if ( is_heap() )
+        {
+            storage_.heap_.data_     = al::grow_to( storage_.heap_.data_, storage_.heap_.capacity_, new_capacity );
+            storage_.heap_.capacity_ = new_capacity;
+        }
+        else
+        {
+            auto const sz{ size() };
+            auto const p { al::allocate( new_capacity ) };
+            std::memcpy( static_cast<void *>( p ), storage_.buffer_.data, sz * sizeof( T ) );
+            set_heap_state( p, new_capacity, sz );
+        }
+    }
+
+private:
+    sz_t   size_;    // LSB = heap flag, actual size = size_ >> 1 (at offset 0 → first byte on LE)
+    data_t storage_;
+}; // class small_vector (compact_lsb)
+
+
+////////////////////////////////////////////////////////////////////////////////
+// is_trivially_moveable specializations
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, std::uint32_t N, typename sz_t, small_vector_options opts>
+requires( opts.layout == small_vector_layout::compact )
+bool constexpr is_trivially_moveable<small_vector<T, N, sz_t, opts>>{ is_trivially_moveable<T> };
+
+template <typename T, std::uint32_t N, typename sz_t, small_vector_options opts>
+requires( opts.layout == small_vector_layout::compact_lsb )
+bool constexpr is_trivially_moveable<small_vector<T, N, sz_t, opts>>{ is_trivially_moveable<T> };
+
+template <typename T, std::uint32_t N, typename sz_t, small_vector_options opts>
+requires( opts.layout == small_vector_layout::pointer_based )
+bool constexpr is_trivially_moveable<small_vector<T, N, sz_t, opts>>{ false };
+
+
+////////////////////////////////////////////////////////////////////////////////
+// C++20-style free-function erasure (ADL)
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, std::uint32_t N, typename sz_t, small_vector_options opts, typename Pred>
+constexpr typename small_vector<T, N, sz_t, opts>::size_type
+erase_if( small_vector<T, N, sz_t, opts> & c, Pred pred )
+{
+    auto const it{ std::remove_if( c.begin(), c.end(), std::move( pred ) ) };
+    auto const n { static_cast<typename small_vector<T, N, sz_t, opts>::size_type>( c.end() - it ) };
+    c.shrink_by( n );
+    return n;
+}
+
+template <typename T, std::uint32_t N, typename sz_t, small_vector_options opts, typename U>
+constexpr typename small_vector<T, N, sz_t, opts>::size_type
+erase( small_vector<T, N, sz_t, opts> & c, U const & value )
+{
+    return erase_if( c, [&value]( auto const & elem ) { return elem == value; } );
+}
+
+//------------------------------------------------------------------------------
+} // namespace psi::vm
+//------------------------------------------------------------------------------

--- a/include/psi/vm/containers/tr_vector.hpp
+++ b/include/psi/vm/containers/tr_vector.hpp
@@ -377,9 +377,9 @@ private:
 
 struct tr_vector_options
 {
-    std::uint8_t alignment                { 0    }; // 0 -> default
-    bool         cache_capacity           { true }; // if your crt_alloc_size is slow (MSVC)
-    bool         explicit_geometric_growth{ true }; // if your realloc impl is slow (yes MSVC we are looking at you again)
+    std::uint8_t     alignment     { 0    }; // 0 -> default
+    bool             cache_capacity{ true }; // if your crt_alloc_size is slow (MSVC)
+    geometric_growth growth        {};       // geometric growth factor (3/2 = 1.5x default, num == den → disabled)
 }; // struct tr_vector_options
 
 template <typename T, typename sz_t = std::size_t, tr_vector_options options = {}>
@@ -554,8 +554,8 @@ private:
         BOOST_ASSUME( cached_current_capacity == capacity() );
         auto const new_capacity
         {
-            options.explicit_geometric_growth
-                ? std::max( target_size, cached_current_capacity * 3U / 2U )
+            options.growth
+                ? options.growth( target_size, cached_current_capacity )
                 : target_size
         };
         p_array_ = al::grow_to( p_array_, cached_current_capacity, new_capacity );

--- a/include/psi/vm/containers/tr_vector.hpp
+++ b/include/psi/vm/containers/tr_vector.hpp
@@ -418,7 +418,7 @@ public:
     {
         // Swap contents: other's destructor frees our old allocation.
         // (but first clear - to avoid surprising callers with leaving
-        // 'something' in other, i.e. leave only capacity)
+        // 'something' in other, i.e. leave only the capacity)
         this->clear();
         this->p_array_  = std::exchange( other.p_array_ , this->p_array_  );
         this->size_     = std::exchange( other.size_    , this->size_     );
@@ -430,9 +430,7 @@ public:
     constexpr tr_vector & operator=( std::initializer_list<value_type> const data ) { this->assign( data ); return *this; }
     constexpr ~tr_vector() noexcept
     {
-        // for non trivial types have/generate one check for both the destroy
-        // loop and call to free
-        if ( std::is_trivially_destructible_v<T> || p_array_ )
+        if ( p_array_ )
         {
             std::destroy_n( data(), size() );
             storage_free();

--- a/include/psi/vm/containers/vector_impl.hpp
+++ b/include/psi/vm/containers/vector_impl.hpp
@@ -56,6 +56,18 @@ namespace psi::vm
 {
 //------------------------------------------------------------------------------
 
+struct geometric_growth
+{
+    std::uint8_t num{ 3 }; // numerator   (3/2 = 1.5x default)
+    std::uint8_t den{ 2 }; // denominator (num == den → no geometric growth)
+
+    /// Returns max(target_size, current_capacity * num / den).
+    template <std::unsigned_integral T>
+    [[ nodiscard ]] constexpr T operator()( T const target_size, T const current_capacity ) const noexcept { return std::max( target_size, static_cast<T>( current_capacity * num / den ) ); }
+
+    [[ nodiscard ]] explicit constexpr operator bool() const noexcept { return num != den; }
+};
+
 PSI_WARNING_DISABLE_PUSH()
 PSI_WARNING_MSVC_DISABLE( 5030 ) // unrecognized attribute
 

--- a/psi_vm.natvis
+++ b/psi_vm.natvis
@@ -251,4 +251,94 @@
     </Type>
 
 
+    <!-- ================================================================== -->
+    <!-- psi::vm::small_vector                                              -->
+    <!--                                                                     -->
+    <!-- Three layouts: compact (MSB flag), compact_lsb (LSB flag), and     -->
+    <!-- pointer_based. Natvis can't distinguish compact from compact_lsb   -->
+    <!-- (both have storage_ + size_ members). The default compact (MSB)    -->
+    <!-- entries are active below. For compact_lsb, uncomment that block    -->
+    <!-- and comment out the compact entries.                                -->
+    <!--                                                                     -->
+    <!-- pointer_based layout has data_/size_/capacity_ (no storage_), so   -->
+    <!-- compact entries fail and fall through to the pointer_based entry.   -->
+    <!-- ================================================================== -->
+
+    <!-- compact layout (MSB flag, sz_t = unsigned __int64) -->
+    <Type Name="psi::vm::small_vector&lt;*,*,unsigned __int64,*&gt;" Priority="MediumHigh">
+        <DisplayString Condition="(size_ &amp; 0x8000000000000000) != 0">{{ size={size_ &amp; 0x7FFFFFFFFFFFFFFF}, heap }}</DisplayString>
+        <DisplayString>{{ size={size_}, inline }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">size_ &amp; 0x7FFFFFFFFFFFFFFF</Item>
+            <Item Name="[capacity]" Condition="(size_ &amp; 0x8000000000000000) != 0" ExcludeView="simple">storage_.heap_.capacity_</Item>
+            <Item Name="[heap]" ExcludeView="simple">(size_ &amp; 0x8000000000000000) != 0</Item>
+            <ArrayItems>
+                <Size>size_ &amp; 0x7FFFFFFFFFFFFFFF</Size>
+                <ValuePointer>((size_ &amp; 0x8000000000000000) != 0) ? storage_.heap_.data_ : storage_.buffer_.data</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <!-- compact layout (MSB flag, sz_t = unsigned int) -->
+    <Type Name="psi::vm::small_vector&lt;*,*,unsigned int,*&gt;" Priority="MediumHigh">
+        <DisplayString Condition="(size_ &amp; 0x80000000) != 0">{{ size={size_ &amp; 0x7FFFFFFF}, heap }}</DisplayString>
+        <DisplayString>{{ size={size_}, inline }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">size_ &amp; 0x7FFFFFFF</Item>
+            <Item Name="[capacity]" Condition="(size_ &amp; 0x80000000) != 0" ExcludeView="simple">storage_.heap_.capacity_</Item>
+            <Item Name="[heap]" ExcludeView="simple">(size_ &amp; 0x80000000) != 0</Item>
+            <ArrayItems>
+                <Size>size_ &amp; 0x7FFFFFFF</Size>
+                <ValuePointer>((size_ &amp; 0x80000000) != 0) ? storage_.heap_.data_ : storage_.buffer_.data</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <!-- compact_lsb layout (LSB flag, any sz_t) — uncomment if using compact_lsb:
+    <Type Name="psi::vm::small_vector&lt;*,*,*,*&gt;" Priority="MediumHigh">
+        <DisplayString Condition="(size_ &amp; 1) != 0">{{ size={size_ >> 1}, heap }}</DisplayString>
+        <DisplayString>{{ size={size_ >> 1}, inline }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">size_ >> 1</Item>
+            <Item Name="[capacity]" Condition="(size_ &amp; 1) != 0" ExcludeView="simple">storage_.heap_.capacity_</Item>
+            <Item Name="[heap]" ExcludeView="simple">(size_ &amp; 1) != 0</Item>
+            <ArrayItems>
+                <Size>size_ >> 1</Size>
+                <ValuePointer>((size_ &amp; 1) != 0) ? storage_.heap_.data_ : storage_.buffer_.data</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+    -->
+
+    <!-- pointer_based layout: data_/size_/capacity_ from small_vector_base -->
+    <Type Name="psi::vm::small_vector&lt;*,*,*,*&gt;" Priority="Medium">
+        <DisplayString>{{ size={size_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">size_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">capacity_</Item>
+            <ArrayItems>
+                <Size>size_</Size>
+                <ValuePointer>data_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+
+    <!-- ================================================================== -->
+    <!-- psi::vm::small_vector_base (type-erased reference, pointer_based)  -->
+    <!-- ================================================================== -->
+
+    <Type Name="psi::vm::small_vector_base&lt;*,*,*&gt;">
+        <DisplayString>{{ size={size_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">size_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">capacity_</Item>
+            <ArrayItems>
+                <Size>size_</Size>
+                <ValuePointer>data_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+
 </AutoVisualizer>

--- a/src/containers/vm_vector.cpp
+++ b/src/containers/vm_vector.cpp
@@ -50,13 +50,13 @@ contiguous_storage::client_to_storage_size( size_type const sz ) const noexcept
 void * contiguous_storage::expand_capacity( std::size_t const target_capacity )
 {
     BOOST_ASSUME( target_capacity > mapped_size() );
-    // basic (1.5x) geometric growth implementation
-    // TODO: make this configurable (and probably move out/down to container
-    // class templates)
+    // geometric growth (1.5x default)
+    // TODO: make this configurable (move out/down to container class templates)
     auto const current_fc_capacity{ storage_size() };
     if ( current_fc_capacity < target_capacity ) [[ unlikely ]]
     {
-        auto const new_fs_capacity{ std::max( target_capacity, current_fc_capacity * 3U / 2U ) };
+        constexpr geometric_growth growth;
+        auto const new_fs_capacity{ growth( target_capacity, current_fc_capacity ) };
         set_size( mapping_, new_fs_capacity );
     }
     return expand_view( target_capacity );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set( vm_test_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/b+tree.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/flat_map.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/flat_set.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/small_vector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/vector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/vm_vector.cpp"
 )
@@ -35,3 +36,12 @@ set_target_properties(
 PSI_target_fix_debug_symbols_for_osx_lto( vm_unit_tests )
 
 add_test( "vm_unit_tests" vm_unit_tests )
+
+# Codegen comparison for small_vector layouts (not a test — for disassembly inspection)
+add_library( small_vector_codegen OBJECT EXCLUDE_FROM_ALL
+    "${CMAKE_CURRENT_SOURCE_DIR}/small_vector_codegen.cpp"
+)
+target_link_libraries( small_vector_codegen PRIVATE psi::vm )
+if ( NOT MSVC OR CLANG_CL )
+    target_precompile_headers( small_vector_codegen REUSE_FROM psi_vm )
+endif()

--- a/test/codegen_compare.cpp
+++ b/test/codegen_compare.cpp
@@ -1,0 +1,133 @@
+////////////////////////////////////////////////////////////////////////////////
+/// Codegen comparison: pass_in_reg vs raw const& for non-inlined lower_bound
+///
+/// Compile with:
+///   clang++ -std=c++26 -stdlib=libc++ -O2 -S -o codegen_compare.s codegen_compare.cpp \
+///     -I<include-path-to-psi/vm> -I<boost-includes>
+///
+/// Or use the CMake build: cmake --build . --target codegen_compare
+///
+/// Look for these functions in the assembly:
+///   lower_bound_ref_*    — baseline: Key const &
+///   lower_bound_reg_*    — proposed: pass_in_reg<Key>
+////////////////////////////////////////////////////////////////////////////////
+
+#include <psi/vm/containers/flat_set.hpp>
+#include <psi/vm/containers/flat_map.hpp>
+
+#include <string>
+#include <vector>
+
+using namespace psi::vm;
+
+//==============================================================================
+// Type aliases for the test containers
+//==============================================================================
+using int_vec    = std::vector<int>;
+using string_vec = std::vector<std::string>;
+
+//==============================================================================
+// Variant A: Key passed as const& (current approach)
+//==============================================================================
+
+template <typename It, typename Key, typename Comp>
+[[ gnu::noinline ]] It lower_bound_ref( It first, It last, Key const & key, Comp const & comp ) {
+    return std::lower_bound( first, last, key, comp );
+}
+
+template <typename It, typename Key, typename Comp>
+[[ gnu::noinline ]] It upper_bound_ref( It first, It last, Key const & key, Comp const & comp ) {
+    return std::upper_bound( first, last, key, comp );
+}
+
+//==============================================================================
+// Variant B: Key passed as pass_in_reg (proposed approach)
+//==============================================================================
+
+template <typename It, typename Key, typename Comp>
+[[ gnu::noinline ]] It lower_bound_reg( It first, It last, pass_in_reg<Key> key, Comp const & comp ) {
+    return std::lower_bound( first, last, key.value, comp );
+}
+
+template <typename It, typename Key, typename Comp>
+[[ gnu::noinline ]] It upper_bound_reg( It first, It last, pass_in_reg<Key> key, Comp const & comp ) {
+    return std::upper_bound( first, last, key.value, comp );
+}
+
+//==============================================================================
+// Explicit instantiations to force codegen
+//==============================================================================
+
+// --- int key, std::less<> (transparent) ---
+template int_vec::const_iterator lower_bound_ref<int_vec::const_iterator, int, std::less<>>( int_vec::const_iterator, int_vec::const_iterator, int const &, std::less<> const & );
+template int_vec::const_iterator lower_bound_reg<int_vec::const_iterator, int, std::less<>>( int_vec::const_iterator, int_vec::const_iterator, pass_in_reg<int>, std::less<> const & );
+
+template int_vec::const_iterator upper_bound_ref<int_vec::const_iterator, int, std::less<>>( int_vec::const_iterator, int_vec::const_iterator, int const &, std::less<> const & );
+template int_vec::const_iterator upper_bound_reg<int_vec::const_iterator, int, std::less<>>( int_vec::const_iterator, int_vec::const_iterator, pass_in_reg<int>, std::less<> const & );
+
+// --- string key, std::less<> (transparent → pass_in_reg stores string_view) ---
+template string_vec::const_iterator lower_bound_ref<string_vec::const_iterator, std::string, std::less<>>( string_vec::const_iterator, string_vec::const_iterator, std::string const &, std::less<> const & );
+template string_vec::const_iterator lower_bound_reg<string_vec::const_iterator, std::string, std::less<>>( string_vec::const_iterator, string_vec::const_iterator, pass_in_reg<std::string>, std::less<> const & );
+
+template string_vec::const_iterator upper_bound_ref<string_vec::const_iterator, std::string, std::less<>>( string_vec::const_iterator, string_vec::const_iterator, std::string const &, std::less<> const & );
+template string_vec::const_iterator upper_bound_reg<string_vec::const_iterator, std::string, std::less<>>( string_vec::const_iterator, string_vec::const_iterator, pass_in_reg<std::string>, std::less<> const & );
+
+// NOTE: std::less<std::string> (non-transparent) + pass_in_reg<string> is intentionally
+// NOT tested — pass_in_reg converts string to string_view, which non-transparent
+// comparators can't handle. This is exactly why key_const_arg only uses pass_in_reg
+// when transparent_comparator is true or the key is trivially passable in reg.
+
+
+//==============================================================================
+// Callers — to see how the call site codegen differs
+//==============================================================================
+
+[[ gnu::noinline ]]
+auto caller_int_ref( int_vec const & v, int key ) {
+    return lower_bound_ref( v.begin(), v.end(), key, std::less<>{} );
+}
+
+[[ gnu::noinline ]]
+auto caller_int_reg( int_vec const & v, int key ) {
+    return lower_bound_reg<int_vec::const_iterator, int, std::less<>>( v.begin(), v.end(), pass_in_reg<int>{ key }, std::less<>{} );
+}
+
+[[ gnu::noinline ]]
+auto caller_string_ref( string_vec const & v, std::string const & key ) {
+    return lower_bound_ref( v.begin(), v.end(), key, std::less<>{} );
+}
+
+[[ gnu::noinline ]]
+auto caller_string_reg( string_vec const & v, std::string const & key ) {
+    return lower_bound_reg<string_vec::const_iterator, std::string, std::less<>>( v.begin(), v.end(), pass_in_reg<std::string>{ key }, std::less<>{} );
+}
+
+// caller with string_view directly (ideal case — no string object at all)
+[[ gnu::noinline ]]
+auto caller_string_reg_sv( string_vec const & v, std::string_view key ) {
+    return lower_bound_reg<string_vec::const_iterator, std::string, std::less<>>( v.begin(), v.end(), pass_in_reg<std::string>{ key }, std::less<>{} );
+}
+
+
+//==============================================================================
+// flat_set integration test — how the container's own lower_bound looks
+//==============================================================================
+
+using int_set       = flat_set<int>;
+using string_set    = flat_set<std::string>;
+using string_set_tr = flat_set<std::string, std::less<>>; // transparent
+
+[[ gnu::noinline ]]
+auto set_find_int( int_set const & s, int key ) {
+    return s.find( key );
+}
+
+[[ gnu::noinline ]]
+auto set_find_string( string_set const & s, std::string const & key ) {
+    return s.find( key );
+}
+
+[[ gnu::noinline ]]
+auto set_find_string_tr( string_set_tr const & s, std::string_view key ) {
+    return s.find( key );
+}

--- a/test/small_vector.cpp
+++ b/test/small_vector.cpp
@@ -1,0 +1,711 @@
+// Small-vector-specific tests: inline storage, transitions, type erasure, etc.
+#include <psi/vm/containers/small_vector.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+//------------------------------------------------------------------------------
+namespace psi::vm
+{
+//------------------------------------------------------------------------------
+
+inline constexpr small_vector_options pb_opts { .layout = small_vector_layout::pointer_based };
+inline constexpr small_vector_options lsb_opts{ .layout = small_vector_layout::compact_lsb   };
+template <typename T, std::uint32_t N>
+using pb_small_vector  = small_vector<T, N, std::size_t, pb_opts>;
+template <typename T, std::uint32_t N>
+using lsb_small_vector = small_vector<T, N, std::size_t, lsb_opts>;
+
+////////////////////////////////////////////////////////////////////////////////
+// Compact layout tests
+////////////////////////////////////////////////////////////////////////////////
+
+TEST( small_vector_compact, inline_storage )
+{
+    small_vector<int, 4> v;
+    v.push_back( 1 );
+    v.push_back( 2 );
+    v.push_back( 3 );
+
+    // Data should be within the object (inline buffer)
+    auto const obj_begin{ reinterpret_cast<std::uintptr_t>( &v ) };
+    auto const obj_end  { obj_begin + sizeof( v ) };
+    auto const data_addr{ reinterpret_cast<std::uintptr_t>( v.data() ) };
+    EXPECT_GE( data_addr, obj_begin );
+    EXPECT_LT( data_addr, obj_end   );
+}
+
+TEST( small_vector_compact, inline_to_heap_transition )
+{
+    small_vector<int, 4> v;
+    for ( int i{ 0 }; i < 4; ++i )
+        v.push_back( i );
+
+    // Still inline
+    auto const obj_begin{ reinterpret_cast<std::uintptr_t>( &v ) };
+    auto const obj_end  { obj_begin + sizeof( v ) };
+    auto data_addr{ reinterpret_cast<std::uintptr_t>( v.data() ) };
+    EXPECT_GE( data_addr, obj_begin );
+    EXPECT_LT( data_addr, obj_end   );
+
+    // Push one more — triggers heap transition
+    v.push_back( 4 );
+    data_addr = reinterpret_cast<std::uintptr_t>( v.data() );
+    EXPECT_TRUE( data_addr < obj_begin || data_addr >= obj_end );
+
+    // Verify all values survived
+    for ( int i{ 0 }; i < 5; ++i )
+        EXPECT_EQ( v[ i ], i );
+}
+
+TEST( small_vector_compact, move_from_inline )
+{
+    small_vector<int, 8> src;
+    for ( int i{ 0 }; i < 4; ++i )
+        src.push_back( i * 10 );
+
+    small_vector<int, 8> dst{ std::move( src ) };
+    EXPECT_EQ( dst.size(), 4u );
+    EXPECT_EQ( src.size(), 0u );
+    for ( int i{ 0 }; i < 4; ++i )
+        EXPECT_EQ( dst[ i ], i * 10 );
+}
+
+TEST( small_vector_compact, move_from_heap )
+{
+    small_vector<int, 2> src;
+    for ( int i{ 0 }; i < 10; ++i )
+        src.push_back( i );
+
+    auto const heap_ptr{ src.data() };
+    small_vector<int, 2> dst{ std::move( src ) };
+    EXPECT_EQ( dst.size(), 10u );
+    EXPECT_EQ( src.size(), 0u );
+    // Should have stolen the pointer
+    EXPECT_EQ( dst.data(), heap_ptr );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( dst[ i ], i );
+}
+
+TEST( small_vector_compact, copy_from_inline )
+{
+    small_vector<int, 8> src;
+    for ( int i{ 0 }; i < 4; ++i )
+        src.push_back( i );
+
+    small_vector<int, 8> dst{ src };
+    EXPECT_EQ( dst.size(), 4u );
+    EXPECT_EQ( src.size(), 4u );
+    EXPECT_NE( dst.data(), src.data() );
+    for ( int i{ 0 }; i < 4; ++i )
+        EXPECT_EQ( dst[ i ], src[ i ] );
+}
+
+TEST( small_vector_compact, copy_from_heap )
+{
+    small_vector<int, 2> src;
+    for ( int i{ 0 }; i < 10; ++i )
+        src.push_back( i );
+
+    small_vector<int, 2> dst{ src };
+    EXPECT_EQ( dst.size(), 10u );
+    EXPECT_NE( dst.data(), src.data() );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( dst[ i ], src[ i ] );
+}
+
+TEST( small_vector_compact, move_assign_inline_to_inline )
+{
+    small_vector<int, 8> a{ 1, 2, 3 };
+    small_vector<int, 8> b{ 10, 20 };
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 3u );
+    EXPECT_EQ( b[ 0 ], 1 );
+    EXPECT_EQ( a.size(), 0u );
+}
+
+TEST( small_vector_compact, move_assign_heap_to_inline )
+{
+    small_vector<int, 2> a;
+    for ( int i{ 0 }; i < 10; ++i )
+        a.push_back( i );
+
+    small_vector<int, 2> b{ 1 };
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 10u );
+    EXPECT_EQ( a.size(), 0u );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( b[ i ], i );
+}
+
+TEST( small_vector_compact, move_assign_inline_to_heap )
+{
+    small_vector<int, 4> a{ 1, 2 };
+    small_vector<int, 4> b;
+    for ( int i{ 0 }; i < 10; ++i )
+        b.push_back( i );
+
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 2u );
+    EXPECT_EQ( b[ 0 ], 1 );
+    EXPECT_EQ( a.size(), 0u );
+}
+
+TEST( small_vector_compact, move_assign_heap_to_heap )
+{
+    small_vector<int, 2> a;
+    small_vector<int, 2> b;
+    for ( int i{ 0 }; i < 10; ++i )
+        a.push_back( i );
+    for ( int i{ 0 }; i < 5; ++i )
+        b.push_back( i * 100 );
+
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 10u );
+    EXPECT_EQ( a.size(), 0u );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( b[ i ], i );
+}
+
+TEST( small_vector_compact, erase_if_free_function )
+{
+    small_vector<int, 8> v{ 1, 2, 3, 4, 5, 6 };
+    auto const removed{ erase_if( v, []( int x ) { return x % 2 == 0; } ) };
+    EXPECT_EQ( removed, 3u );
+    EXPECT_EQ( v.size(), 3u );
+    EXPECT_EQ( v[ 0 ], 1 );
+    EXPECT_EQ( v[ 1 ], 3 );
+    EXPECT_EQ( v[ 2 ], 5 );
+}
+
+TEST( small_vector_compact, erase_free_function )
+{
+    small_vector<int, 8> v{ 1, 2, 3, 2, 4, 2 };
+    auto const removed{ erase( v, 2 ) };
+    EXPECT_EQ( removed, 3u );
+    EXPECT_EQ( v.size(), 3u );
+    EXPECT_EQ( v[ 0 ], 1 );
+    EXPECT_EQ( v[ 1 ], 3 );
+    EXPECT_EQ( v[ 2 ], 4 );
+}
+
+TEST( small_vector_compact, stress_push_clear_push )
+{
+    small_vector<int, 4> v;
+    for ( int i{ 0 }; i < 1000; ++i )
+        v.push_back( i );
+    EXPECT_EQ( v.size(), 1000u );
+
+    v.clear();
+    EXPECT_EQ( v.size(), 0u );
+
+    for ( int i{ 0 }; i < 500; ++i )
+        v.push_back( i * 2 );
+    EXPECT_EQ( v.size(), 500u );
+    EXPECT_EQ( v[ 0 ], 0 );
+    EXPECT_EQ( v[ 499 ], 998 );
+}
+
+TEST( small_vector_compact, trivially_relocatable )
+{
+    static_assert(  is_trivially_moveable<small_vector<int, 4>> );
+    static_assert(  is_trivially_moveable<small_vector<int, 16, std::uint32_t>> );
+    static_assert( !is_trivially_moveable<pb_small_vector<int, 4>> );
+}
+
+TEST( small_vector_compact, reserve_inline )
+{
+    small_vector<int, 8> v;
+    v.reserve( 4 ); // within inline capacity — should stay inline
+    EXPECT_GE( v.capacity(), 4u );
+
+    auto const obj_begin{ reinterpret_cast<std::uintptr_t>( &v ) };
+    auto const obj_end  { obj_begin + sizeof( v ) };
+    auto const data_addr{ reinterpret_cast<std::uintptr_t>( v.data() ) };
+    EXPECT_GE( data_addr, obj_begin );
+    EXPECT_LT( data_addr, obj_end   );
+}
+
+TEST( small_vector_compact, reserve_heap )
+{
+    small_vector<int, 4> v;
+    v.reserve( 100 ); // exceeds inline — should go to heap
+    EXPECT_GE( v.capacity(), 100u );
+    EXPECT_EQ( v.size(), 0u );
+
+    for ( int i{ 0 }; i < 100; ++i )
+        v.push_back( i );
+    EXPECT_EQ( v.size(), 100u );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Pointer-based layout tests
+////////////////////////////////////////////////////////////////////////////////
+
+TEST( small_vector_pointer, inline_storage )
+{
+    pb_small_vector<int, 4> v;
+    v.push_back( 1 );
+    v.push_back( 2 );
+    v.push_back( 3 );
+
+    EXPECT_TRUE( v.is_small() );
+    auto const obj_begin{ reinterpret_cast<std::uintptr_t>( &v ) };
+    auto const obj_end  { obj_begin + sizeof( v ) };
+    auto const data_addr{ reinterpret_cast<std::uintptr_t>( v.data() ) };
+    EXPECT_GE( data_addr, obj_begin );
+    EXPECT_LT( data_addr, obj_end   );
+}
+
+TEST( small_vector_pointer, inline_to_heap_transition )
+{
+    pb_small_vector<int, 4> v;
+    for ( int i{ 0 }; i < 4; ++i )
+        v.push_back( i );
+
+    EXPECT_TRUE( v.is_small() );
+
+    // Push one more — triggers heap transition
+    v.push_back( 4 );
+    EXPECT_FALSE( v.is_small() );
+
+    auto const obj_begin{ reinterpret_cast<std::uintptr_t>( &v ) };
+    auto const obj_end  { obj_begin + sizeof( v ) };
+    auto const data_addr{ reinterpret_cast<std::uintptr_t>( v.data() ) };
+    EXPECT_TRUE( data_addr < obj_begin || data_addr >= obj_end );
+
+    for ( int i{ 0 }; i < 5; ++i )
+        EXPECT_EQ( v[ i ], i );
+}
+
+TEST( small_vector_pointer, move_from_inline )
+{
+    pb_small_vector<int, 8> src;
+    for ( int i{ 0 }; i < 4; ++i )
+        src.push_back( i * 10 );
+
+    EXPECT_TRUE( src.is_small() );
+    pb_small_vector<int, 8> dst{ std::move( src ) };
+    EXPECT_EQ( dst.size(), 4u );
+    EXPECT_EQ( src.size(), 0u );
+    EXPECT_TRUE( dst.is_small() );
+    EXPECT_TRUE( src.is_small() );
+    for ( int i{ 0 }; i < 4; ++i )
+        EXPECT_EQ( dst[ i ], i * 10 );
+}
+
+TEST( small_vector_pointer, move_from_heap )
+{
+    pb_small_vector<int, 2> src;
+    for ( int i{ 0 }; i < 10; ++i )
+        src.push_back( i );
+
+    EXPECT_FALSE( src.is_small() );
+    auto const heap_ptr{ src.data() };
+    pb_small_vector<int, 2> dst{ std::move( src ) };
+    EXPECT_EQ( dst.size(), 10u );
+    EXPECT_EQ( src.size(), 0u );
+    EXPECT_FALSE( dst.is_small() );
+    EXPECT_TRUE ( src.is_small() );
+    // Should have stolen the pointer
+    EXPECT_EQ( dst.data(), heap_ptr );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( dst[ i ], i );
+}
+
+TEST( small_vector_pointer, copy_from_inline )
+{
+    pb_small_vector<int, 8> src;
+    for ( int i{ 0 }; i < 4; ++i )
+        src.push_back( i );
+
+    pb_small_vector<int, 8> dst{ src };
+    EXPECT_EQ( dst.size(), 4u );
+    EXPECT_EQ( src.size(), 4u );
+    EXPECT_TRUE( dst.is_small() );
+    EXPECT_NE( dst.data(), src.data() );
+    for ( int i{ 0 }; i < 4; ++i )
+        EXPECT_EQ( dst[ i ], src[ i ] );
+}
+
+TEST( small_vector_pointer, copy_from_heap )
+{
+    pb_small_vector<int, 2> src;
+    for ( int i{ 0 }; i < 10; ++i )
+        src.push_back( i );
+
+    pb_small_vector<int, 2> dst{ src };
+    EXPECT_EQ( dst.size(), 10u );
+    EXPECT_FALSE( dst.is_small() );
+    EXPECT_NE( dst.data(), src.data() );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( dst[ i ], src[ i ] );
+}
+
+TEST( small_vector_pointer, move_assign_inline_to_inline )
+{
+    pb_small_vector<int, 8> a{ 1, 2, 3 };
+    pb_small_vector<int, 8> b{ 10, 20 };
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 3u );
+    EXPECT_EQ( b[ 0 ], 1 );
+    EXPECT_EQ( a.size(), 0u );
+    EXPECT_TRUE( b.is_small() );
+}
+
+TEST( small_vector_pointer, move_assign_heap_to_inline )
+{
+    pb_small_vector<int, 2> a;
+    for ( int i{ 0 }; i < 10; ++i )
+        a.push_back( i );
+
+    pb_small_vector<int, 2> b{ 1 };
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 10u );
+    EXPECT_EQ( a.size(), 0u );
+    EXPECT_FALSE( b.is_small() );
+    EXPECT_TRUE ( a.is_small() );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( b[ i ], i );
+}
+
+TEST( small_vector_pointer, move_assign_inline_to_heap )
+{
+    pb_small_vector<int, 4> a{ 1, 2 };
+    pb_small_vector<int, 4> b;
+    for ( int i{ 0 }; i < 10; ++i )
+        b.push_back( i );
+
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 2u );
+    EXPECT_EQ( b[ 0 ], 1 );
+    EXPECT_EQ( a.size(), 0u );
+    EXPECT_TRUE( b.is_small() );
+}
+
+TEST( small_vector_pointer, move_assign_heap_to_heap )
+{
+    pb_small_vector<int, 2> a;
+    pb_small_vector<int, 2> b;
+    for ( int i{ 0 }; i < 10; ++i )
+        a.push_back( i );
+    for ( int i{ 0 }; i < 5; ++i )
+        b.push_back( i * 100 );
+
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 10u );
+    EXPECT_EQ( a.size(), 0u );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( b[ i ], i );
+}
+
+TEST( small_vector_pointer, erase_if_free_function )
+{
+    pb_small_vector<int, 8> v{ 1, 2, 3, 4, 5, 6 };
+    auto const removed{ erase_if( v, []( int x ) { return x % 2 == 0; } ) };
+    EXPECT_EQ( removed, 3u );
+    EXPECT_EQ( v.size(), 3u );
+    EXPECT_EQ( v[ 0 ], 1 );
+    EXPECT_EQ( v[ 1 ], 3 );
+    EXPECT_EQ( v[ 2 ], 5 );
+}
+
+TEST( small_vector_pointer, erase_free_function )
+{
+    pb_small_vector<int, 8> v{ 1, 2, 3, 2, 4, 2 };
+    auto const removed{ erase( v, 2 ) };
+    EXPECT_EQ( removed, 3u );
+    EXPECT_EQ( v.size(), 3u );
+    EXPECT_EQ( v[ 0 ], 1 );
+    EXPECT_EQ( v[ 1 ], 3 );
+    EXPECT_EQ( v[ 2 ], 4 );
+}
+
+TEST( small_vector_pointer, stress_push_clear_push )
+{
+    pb_small_vector<int, 4> v;
+    for ( int i{ 0 }; i < 1000; ++i )
+        v.push_back( i );
+    EXPECT_EQ( v.size(), 1000u );
+    EXPECT_FALSE( v.is_small() );
+
+    v.clear();
+    EXPECT_EQ( v.size(), 0u );
+
+    for ( int i{ 0 }; i < 500; ++i )
+        v.push_back( i * 2 );
+    EXPECT_EQ( v.size(), 500u );
+    EXPECT_EQ( v[ 0 ], 0 );
+    EXPECT_EQ( v[ 499 ], 998 );
+}
+
+TEST( small_vector_pointer, trivially_relocatable )
+{
+    static_assert( !is_trivially_moveable<pb_small_vector<int, 4>> );
+    static_assert( !is_trivially_moveable<pb_small_vector<int, 16>> );
+}
+
+TEST( small_vector_pointer, reserve_inline )
+{
+    pb_small_vector<int, 8> v;
+    v.reserve( 4 ); // within inline capacity — should stay inline
+    EXPECT_GE( v.capacity(), 4u );
+    EXPECT_TRUE( v.is_small() );
+}
+
+TEST( small_vector_pointer, reserve_heap )
+{
+    pb_small_vector<int, 4> v;
+    v.reserve( 100 );
+    EXPECT_GE( v.capacity(), 100u );
+    EXPECT_EQ( v.size(), 0u );
+    EXPECT_FALSE( v.is_small() );
+
+    for ( int i{ 0 }; i < 100; ++i )
+        v.push_back( i );
+    EXPECT_EQ( v.size(), 100u );
+}
+
+TEST( small_vector_pointer, type_erasure_via_base )
+{
+    pb_small_vector<int, 4>  a{ 1, 2, 3 };
+    pb_small_vector<int, 16> b{ 10, 20 };
+
+    // Both can be referenced through the same base type
+    using base_t = small_vector_base<int, std::size_t, pb_opts>;
+    base_t & a_ref{ a };
+    base_t & b_ref{ b };
+
+    EXPECT_EQ( a_ref.size(), 3u );
+    EXPECT_EQ( b_ref.size(), 2u );
+    EXPECT_EQ( a_ref[ 0 ], 1 );
+    EXPECT_EQ( b_ref[ 0 ], 10 );
+
+    // Can push through base reference
+    a_ref.push_back( 4 );
+    EXPECT_EQ( a_ref.size(), 4u );
+    EXPECT_EQ( a[ 3 ], 4 );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Compact LSB layout tests
+////////////////////////////////////////////////////////////////////////////////
+
+TEST( small_vector_compact_lsb, inline_storage )
+{
+    lsb_small_vector<int, 4> v;
+    v.push_back( 1 );
+    v.push_back( 2 );
+    v.push_back( 3 );
+
+    auto const obj_begin{ reinterpret_cast<std::uintptr_t>( &v ) };
+    auto const obj_end  { obj_begin + sizeof( v ) };
+    auto const data_addr{ reinterpret_cast<std::uintptr_t>( v.data() ) };
+    EXPECT_GE( data_addr, obj_begin );
+    EXPECT_LT( data_addr, obj_end   );
+}
+
+TEST( small_vector_compact_lsb, inline_to_heap_transition )
+{
+    lsb_small_vector<int, 4> v;
+    for ( int i{ 0 }; i < 4; ++i )
+        v.push_back( i );
+
+    auto const obj_begin{ reinterpret_cast<std::uintptr_t>( &v ) };
+    auto const obj_end  { obj_begin + sizeof( v ) };
+    auto data_addr{ reinterpret_cast<std::uintptr_t>( v.data() ) };
+    EXPECT_GE( data_addr, obj_begin );
+    EXPECT_LT( data_addr, obj_end   );
+
+    v.push_back( 4 );
+    data_addr = reinterpret_cast<std::uintptr_t>( v.data() );
+    EXPECT_TRUE( data_addr < obj_begin || data_addr >= obj_end );
+
+    for ( int i{ 0 }; i < 5; ++i )
+        EXPECT_EQ( v[ i ], i );
+}
+
+TEST( small_vector_compact_lsb, move_from_inline )
+{
+    lsb_small_vector<int, 8> src;
+    for ( int i{ 0 }; i < 4; ++i )
+        src.push_back( i * 10 );
+
+    lsb_small_vector<int, 8> dst{ std::move( src ) };
+    EXPECT_EQ( dst.size(), 4u );
+    EXPECT_EQ( src.size(), 0u );
+    for ( int i{ 0 }; i < 4; ++i )
+        EXPECT_EQ( dst[ i ], i * 10 );
+}
+
+TEST( small_vector_compact_lsb, move_from_heap )
+{
+    lsb_small_vector<int, 2> src;
+    for ( int i{ 0 }; i < 10; ++i )
+        src.push_back( i );
+
+    auto const heap_ptr{ src.data() };
+    lsb_small_vector<int, 2> dst{ std::move( src ) };
+    EXPECT_EQ( dst.size(), 10u );
+    EXPECT_EQ( src.size(), 0u );
+    EXPECT_EQ( dst.data(), heap_ptr );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( dst[ i ], i );
+}
+
+TEST( small_vector_compact_lsb, copy_from_inline )
+{
+    lsb_small_vector<int, 8> src;
+    for ( int i{ 0 }; i < 4; ++i )
+        src.push_back( i );
+
+    lsb_small_vector<int, 8> dst{ src };
+    EXPECT_EQ( dst.size(), 4u );
+    EXPECT_EQ( src.size(), 4u );
+    EXPECT_NE( dst.data(), src.data() );
+    for ( int i{ 0 }; i < 4; ++i )
+        EXPECT_EQ( dst[ i ], src[ i ] );
+}
+
+TEST( small_vector_compact_lsb, copy_from_heap )
+{
+    lsb_small_vector<int, 2> src;
+    for ( int i{ 0 }; i < 10; ++i )
+        src.push_back( i );
+
+    lsb_small_vector<int, 2> dst{ src };
+    EXPECT_EQ( dst.size(), 10u );
+    EXPECT_NE( dst.data(), src.data() );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( dst[ i ], src[ i ] );
+}
+
+TEST( small_vector_compact_lsb, move_assign_inline_to_inline )
+{
+    lsb_small_vector<int, 8> a{ 1, 2, 3 };
+    lsb_small_vector<int, 8> b{ 10, 20 };
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 3u );
+    EXPECT_EQ( b[ 0 ], 1 );
+    EXPECT_EQ( a.size(), 0u );
+}
+
+TEST( small_vector_compact_lsb, move_assign_heap_to_inline )
+{
+    lsb_small_vector<int, 2> a;
+    for ( int i{ 0 }; i < 10; ++i )
+        a.push_back( i );
+
+    lsb_small_vector<int, 2> b{ 1 };
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 10u );
+    EXPECT_EQ( a.size(), 0u );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( b[ i ], i );
+}
+
+TEST( small_vector_compact_lsb, move_assign_inline_to_heap )
+{
+    lsb_small_vector<int, 4> a{ 1, 2 };
+    lsb_small_vector<int, 4> b;
+    for ( int i{ 0 }; i < 10; ++i )
+        b.push_back( i );
+
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 2u );
+    EXPECT_EQ( b[ 0 ], 1 );
+    EXPECT_EQ( a.size(), 0u );
+}
+
+TEST( small_vector_compact_lsb, move_assign_heap_to_heap )
+{
+    lsb_small_vector<int, 2> a;
+    lsb_small_vector<int, 2> b;
+    for ( int i{ 0 }; i < 10; ++i )
+        a.push_back( i );
+    for ( int i{ 0 }; i < 5; ++i )
+        b.push_back( i * 100 );
+
+    b = std::move( a );
+    EXPECT_EQ( b.size(), 10u );
+    EXPECT_EQ( a.size(), 0u );
+    for ( int i{ 0 }; i < 10; ++i )
+        EXPECT_EQ( b[ i ], i );
+}
+
+TEST( small_vector_compact_lsb, erase_if_free_function )
+{
+    lsb_small_vector<int, 8> v{ 1, 2, 3, 4, 5, 6 };
+    auto const removed{ erase_if( v, []( int x ) { return x % 2 == 0; } ) };
+    EXPECT_EQ( removed, 3u );
+    EXPECT_EQ( v.size(), 3u );
+    EXPECT_EQ( v[ 0 ], 1 );
+    EXPECT_EQ( v[ 1 ], 3 );
+    EXPECT_EQ( v[ 2 ], 5 );
+}
+
+TEST( small_vector_compact_lsb, erase_free_function )
+{
+    lsb_small_vector<int, 8> v{ 1, 2, 3, 2, 4, 2 };
+    auto const removed{ erase( v, 2 ) };
+    EXPECT_EQ( removed, 3u );
+    EXPECT_EQ( v.size(), 3u );
+    EXPECT_EQ( v[ 0 ], 1 );
+    EXPECT_EQ( v[ 1 ], 3 );
+    EXPECT_EQ( v[ 2 ], 4 );
+}
+
+TEST( small_vector_compact_lsb, stress_push_clear_push )
+{
+    lsb_small_vector<int, 4> v;
+    for ( int i{ 0 }; i < 1000; ++i )
+        v.push_back( i );
+    EXPECT_EQ( v.size(), 1000u );
+
+    v.clear();
+    EXPECT_EQ( v.size(), 0u );
+
+    for ( int i{ 0 }; i < 500; ++i )
+        v.push_back( i * 2 );
+    EXPECT_EQ( v.size(), 500u );
+    EXPECT_EQ( v[ 0 ], 0 );
+    EXPECT_EQ( v[ 499 ], 998 );
+}
+
+TEST( small_vector_compact_lsb, trivially_relocatable )
+{
+    static_assert(  is_trivially_moveable<lsb_small_vector<int, 4>> );
+    static_assert(  is_trivially_moveable<lsb_small_vector<int, 16>> );
+    static_assert(  is_trivially_moveable<small_vector<int, 4, std::uint32_t, lsb_opts>> );
+}
+
+TEST( small_vector_compact_lsb, reserve_inline )
+{
+    lsb_small_vector<int, 8> v;
+    v.reserve( 4 );
+    EXPECT_GE( v.capacity(), 4u );
+
+    auto const obj_begin{ reinterpret_cast<std::uintptr_t>( &v ) };
+    auto const obj_end  { obj_begin + sizeof( v ) };
+    auto const data_addr{ reinterpret_cast<std::uintptr_t>( v.data() ) };
+    EXPECT_GE( data_addr, obj_begin );
+    EXPECT_LT( data_addr, obj_end   );
+}
+
+TEST( small_vector_compact_lsb, reserve_heap )
+{
+    lsb_small_vector<int, 4> v;
+    v.reserve( 100 );
+    EXPECT_GE( v.capacity(), 100u );
+    EXPECT_EQ( v.size(), 0u );
+
+    for ( int i{ 0 }; i < 100; ++i )
+        v.push_back( i );
+    EXPECT_EQ( v.size(), 100u );
+}
+
+//------------------------------------------------------------------------------
+} // namespace psi::vm
+//------------------------------------------------------------------------------

--- a/test/small_vector_codegen.cpp
+++ b/test/small_vector_codegen.cpp
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+/// Codegen comparison for small_vector layouts.
+///
+/// Not a test — standalone functions for disassembly inspection.
+/// Build in Release, disassemble with:
+///   objdump -d -M intel --no-show-raw-insn small_vector_codegen.o | c++filt
+///   dumpbin /disasm small_vector_codegen.obj
+///
+/// Compare the generated code for each layout variant:
+///   compact (MSB flag):  size() = mask, data() = branch on MSB, inc = ++size_
+///   compact_lsb (LSB):   size() = shift, data() = branch on LSB, inc = size_ += 2
+///   pointer_based:       size() = load, data() = load, inc = ++size_
+////////////////////////////////////////////////////////////////////////////////
+
+#include <psi/vm/containers/small_vector.hpp>
+
+namespace psi::vm::codegen
+{
+
+inline constexpr small_vector_options lsb_opts{ .layout = small_vector_layout::compact_lsb   };
+inline constexpr small_vector_options pb_opts { .layout = small_vector_layout::pointer_based };
+
+using sv_compact = small_vector<int, 8>;
+using sv_lsb     = small_vector<int, 8, std::size_t, lsb_opts>;
+using sv_pointer = small_vector<int, 8, std::size_t, pb_opts>;
+
+// --- size() ---
+[[ gnu::noinline ]] std::size_t get_size_compact( sv_compact const & v ) { return v.size(); }
+[[ gnu::noinline ]] std::size_t get_size_lsb    ( sv_lsb     const & v ) { return v.size(); }
+[[ gnu::noinline ]] std::size_t get_size_pointer ( sv_pointer const & v ) { return v.size(); }
+
+// --- data() ---
+[[ gnu::noinline ]] int const * get_data_compact( sv_compact const & v ) { return v.data(); }
+[[ gnu::noinline ]] int const * get_data_lsb    ( sv_lsb     const & v ) { return v.data(); }
+[[ gnu::noinline ]] int const * get_data_pointer ( sv_pointer const & v ) { return v.data(); }
+
+// --- push_back (exercises grow path + size increment) ---
+[[ gnu::noinline ]] void push_compact( sv_compact & v, int x ) { v.push_back( x ); }
+[[ gnu::noinline ]] void push_lsb    ( sv_lsb     & v, int x ) { v.push_back( x ); }
+[[ gnu::noinline ]] void push_pointer( sv_pointer & v, int x ) { v.push_back( x ); }
+
+// --- operator[] (data + offset) ---
+[[ gnu::noinline ]] int read_compact( sv_compact const & v, std::size_t i ) { return v[ i ]; }
+[[ gnu::noinline ]] int read_lsb    ( sv_lsb     const & v, std::size_t i ) { return v[ i ]; }
+[[ gnu::noinline ]] int read_pointer( sv_pointer const & v, std::size_t i ) { return v[ i ]; }
+
+// --- capacity() ---
+[[ gnu::noinline ]] std::size_t get_cap_compact( sv_compact const & v ) { return v.capacity(); }
+[[ gnu::noinline ]] std::size_t get_cap_lsb    ( sv_lsb     const & v ) { return v.capacity(); }
+[[ gnu::noinline ]] std::size_t get_cap_pointer ( sv_pointer const & v ) { return v.capacity(); }
+
+// --- push_back loop (realistic hot path) ---
+[[ gnu::noinline ]] void push_loop_compact( sv_compact & v, int n )
+{
+    for ( int i{ 0 }; i < n; ++i )
+        v.push_back( i );
+}
+[[ gnu::noinline ]] void push_loop_lsb( sv_lsb & v, int n )
+{
+    for ( int i{ 0 }; i < n; ++i )
+        v.push_back( i );
+}
+[[ gnu::noinline ]] void push_loop_pointer( sv_pointer & v, int n )
+{
+    for ( int i{ 0 }; i < n; ++i )
+        v.push_back( i );
+}
+
+} // namespace psi::vm::codegen

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -1,6 +1,7 @@
 // Comprehensive std::vector-like compliance tests for tr_vector and fc_vector
 // using Google Test typed tests to cover both implementations uniformly.
 #include <psi/vm/containers/fc_vector.hpp>
+#include <psi/vm/containers/small_vector.hpp>
 #include <psi/vm/containers/tr_vector.hpp>
 
 #include <gtest/gtest.h>
@@ -20,10 +21,18 @@ namespace psi::vm
 // Typed test suite — runs every test against all vector types
 ////////////////////////////////////////////////////////////////////////////////
 
+inline constexpr small_vector_options pointer_based_opts{ .layout = small_vector_layout::pointer_based };
+inline constexpr small_vector_options compact_lsb_opts  { .layout = small_vector_layout::compact_lsb   };
+
 using VectorTestTypes = ::testing::Types<
     tr_vector<int>,
     tr_vector<int, std::uint32_t>,
-    fc_vector<int, 256>
+    fc_vector<int, 256>,
+    small_vector<int, 16>,
+    small_vector<int, 4, std::uint32_t>,
+    small_vector<int, 8, std::size_t, pointer_based_opts>,
+    small_vector<int, 16, std::size_t, compact_lsb_opts>,
+    small_vector<int, 4, std::uint32_t, compact_lsb_opts>
 >;
 
 template <typename VecType>


### PR DESCRIPTION
# small_vector: inline (stack) buffer with heap spill

## Summary

Implements `small_vector<T, N, sz_t, opts>` — a vector with inline (stack) storage for up to N elements that spills to heap when exceeded. Built on the existing `vector_impl` CRTP base and reuses `crt_aligned_allocator` for the heap path.

All layouts require `is_trivially_moveable<T>` — elements are relocated via memcpy/realloc.

Three layout modes selectable via NTTP `small_vector_options::layout`:

### Layout A: Compact / union-based (default) — MSB flag
- Inspired by libc++ `std::string` SSO — **no self-referential pointer**
- Union of `{T* data_, sz_t capacity_}` heap struct and `noninitialized_array<T,N>` inline buffer
- MSB of `size_` encodes heap/inline discriminant
- `size()` = `size_ & ~heap_flag` (mask); `data()` branches on MSB
- **Trivially relocatable** when `is_trivially_moveable<T>`, marked `[[clang::trivial_abi]]`
- NOT type-erasable across different N values (union size depends on N)

### Layout B: Compact LSB — LSB flag, size-first
- Same union-based structure as compact, but `size_` comes **first** (before the union)
- LSB of `size_` is the heap flag; on little-endian, flag is in byte 0 of the struct
- `size()` = `size_ >> 1` (shift); `is_heap()` = `size_ & 1`
- Increment/decrement by 2 (since size is stored shifted left by 1)
- Optimal for LE: `test byte [ptr], 1` for discriminant check
- **Trivially relocatable**, `[[clang::trivial_abi]]`

### Layout C: Pointer-based (Boost/LLVM SmallVector style)
- Two-level CRTP: `vector_impl` -> `small_vector_base<T,sz_t,opts>` -> `small_vector<T,N,sz_t,opts>`
- `data_` pointer + `size_` + `capacity_` in N-independent base class
- `is_small()` detects inline state by comparing `data_` to computed buffer address
- **Type-erasable**: `small_vector_base<T,sz_t,opts>&` accepts any N
- **NOT trivially relocatable** (self-referential `data_` pointer when inline)

### Layout approach tradeoffs

| Property | compact (MSB) | compact_lsb (LSB) | pointer_based | tag-byte variant* |
|----------|:---:|:---:|:---:|:---:|
| Trivially relocatable | Yes | Yes | No | Yes |
| `[[clang::trivial_abi]]` | Yes | Yes | No | Yes |
| Type-erasable (N-independent ref) | No | No | Yes | No |
| `data()` cost | branch | branch | load | branch |
| `size()` cost | mask | shift | load | load |
| `is_heap()` cost | MSB test | LSB test | ptr compare | LSB test |
| `++size` cost | `++` | `+= 2` | `++` | `++` |
| Max size | `sz_t/2` | `sz_t/2` | `sz_t` | `sz_t` |
| Flag at byte 0 (LE) | No | Yes | N/A | Yes |
| Inline buffer waste | 0 | 0 | 0 | `alignof(T)` bytes |

\* **Tag-byte variant** (not implemented): union where heap side stores aligned pointer + capacity, inline side has a tag byte with LSB=1 followed by alignment-padded buffer data, and `size_` is a separate field with no flag bits. Trades `alignof(T)` bytes of inline capacity for a clean `size()` (no mask/shift) and full `sz_t` range.

### `geometric_growth` struct

Extracted a reusable `geometric_growth` struct into `vector_impl.hpp` (shared by all vector types):
```cpp
struct geometric_growth {
    uint8_t num{ 3 };  // numerator
    uint8_t den{ 2 };  // denominator (3/2 = 1.5x default)

    template <std::unsigned_integral T>
    constexpr T operator()( T target_size, T current_capacity ) const noexcept;
    explicit constexpr operator bool() const noexcept; // false when num == den (disabled)
};
```
- `operator(target, cap)` returns `max(target, cap * num / den)` — the recurring growth pattern
- `operator bool` → false when `num == den` (growth disabled, just use target size)
- Used by: `small_vector` (default 5/4 = 1.25x), `tr_vector` (default 3/2 = 1.5x), `vm_vector::expand_capacity` (default 3/2 = 1.5x)
- Replaces: `tr_vector_options::explicit_geometric_growth` (bool), hardcoded `* 3U / 2U` in vm_vector, `growth_num`/`growth_den` fields in `small_vector_options`

## Files changed

### New files
- **`containers/noninitialized_array.hpp`** — extracted from `fc_vector.hpp` (shared utility)
- **`containers/small_vector.hpp`** — all three layout implementations, options enum/struct, `erase`/`erase_if` free functions, `is_trivially_moveable` specializations
- **`test/small_vector.cpp`** — 49 layout-specific tests (16 compact + 17 pointer-based + 16 compact_lsb)
- **`test/small_vector_codegen.cpp`** — standalone functions for disassembly comparison across layouts

### Modified files
- **`containers/vector_impl.hpp`** — added `geometric_growth` struct
- **`containers/tr_vector.hpp`** — replaced `explicit_geometric_growth` bool with `geometric_growth growth` in `tr_vector_options`; updated `do_grow` to use it
- **`containers/fc_vector.hpp`** — replaced inline `noninitialized_array` with `#include "noninitialized_array.hpp"`
- **`src/containers/vm_vector.cpp`** — replaced hardcoded `* 3U / 2U` with `geometric_growth` in `expand_capacity`
- **`test/vector.cpp`** — added 5 small_vector variants (2 compact, 1 pointer-based, 2 compact_lsb) to compliance test types (85 tests each = 425 compliance tests)
- **`test/CMakeLists.txt`** — added `small_vector.cpp` to test sources + `small_vector_codegen` object library target
- **`psi_vm.natvis`** — debugger visualizers for all layouts + `small_vector_base` + commented-out compact_lsb entry
- **`README.md`** — added `small_vector` to the Vectors table

## Codegen comparison (Clang 21.1, -O3, x86-64 SysV)

| Operation    | compact (MSB) | compact_lsb (LSB) | pointer_based |
|:-------------|:---:|:---:|:---:|
| `size()`     | 3   | 3   | **2** |
| `data()`     | 5   | 7   | **2** |
| `v[i]`       | 5   | 8   | **3** |
| `capacity()` | 5   | 5   | **2** |
| `push_back`  | 32  | 41  | **20** |
| `push_loop`  | 42  | 41  | **28** |

## Benchmark (Clang 21, -O3, WSL Arch)

push_back N elements (best of 1000, nanoseconds):

|   N  | compact | compact_lsb | pointer |
|-----:|--------:|------------:|--------:|
|    4 |      15 |          16 |      14 |
|    8 |      17 |          19 |      15 |
|   64 |      75 |          81 |      59 |
|  256 |     204 |         246 |     140 |
| 1024 |     729 |         918 |     481 |
| 4096 |    2754 |        3517 |    1770 |

Read iteration and random access are identical across layouts (dominated by memory access, not discriminant check).

## Test results

| Platform | Tests | Result |
|----------|-------|--------|
| Windows MSVC native | 755 | PASSED |
| WSL Arch Clang+libc++ | 755 | PASSED |

Total new tests: 474 (49 layout-specific + 425 compliance)
