### PR TITLE
Fixed bp_tree_impl<>::replace_keys_inplace() to update separators for…

### DIFF
--- a/include/psi/vm/containers/b+tree.hpp
+++ b/include/psi/vm/containers/b+tree.hpp
@@ -1492,7 +1492,7 @@ protected: // 'other'
         node_size_type const missing_values( node.min_values - node.num_vals );
 
         // It may happen that a leaf's separator key appears not in the
-        // immediate parent but further up - which would require more complex
+        // immediate parent but further up - which would require a more complex
         // (recursive climb) logic to update it (like other functions which call
         // update_separator) - however this is not in fact necessary since:
         // - this may happen only for the leftmost children (leaves) of a given
@@ -2515,7 +2515,7 @@ protected:
         return
         {
             leaf,
-            BOOST_LIKELY( !separator_key_node ) ? lower_bound( leaf, key ) : find_pos{ 0, true }, // short circuit since we know separator key only exist for first keys
+            BOOST_LIKELY( !separator_key_node ) ? lower_bound( leaf, key ) : find_pos{ 0, true }, // short circuit since we know separator keys only exist for first keys
             separator_key_offset,
             separator_key_node
         };
@@ -2787,6 +2787,9 @@ bp_tree_impl<Key, Comparator>::replace_keys_inplace( std::span<Key const> const 
             "Replacement key must compare equivalent to old key (same ordering position)"
         );
         p_leaf->keys[ offset ] = new_keys[ key_idx ];
+        if ( offset == 0 ) [[ unlikely ]] {
+            this->update_separator( *p_leaf, new_keys[ key_idx ] );
+        }
         p_leaf->mark_dirty();
         ++replaced;
         ++key_idx;

--- a/test/b+tree.cpp
+++ b/test/b+tree.cpp
@@ -718,6 +718,60 @@ TEST( bp_tree, replace_keys_inplace_large_tree )
     indirect_values.clear();
 }
 
+TEST( bp_tree, replace_keys_inplace_stale_separator_underflow_repro )
+{
+#ifdef NDEBUG
+    GTEST_SKIP() << "Requires assertions enabled";
+#else
+    using tree_type = psi::vm::bp_tree<unsigned, true, indirect_comparator>;
+
+    tree_type bpt;
+    bpt.map_memory();
+
+    auto constexpr max_per_node{ tree_type::leaf_node::max_values };
+    auto constexpr min_per_node{ tree_type::leaf_node::min_values };
+    auto const test_size{ max_per_node * 3U };
+    auto const offset{ test_size };
+
+    indirect_values.resize( test_size * 2 );
+    for ( auto i{ 0U }; i < test_size; ++i ) {
+        indirect_values[ i ] = static_cast<int>( i );
+        indirect_values[ i + offset ] = static_cast<int>( i );
+    }
+
+    std::vector<unsigned> keys( test_size );
+    for ( auto i{ 0U }; i < test_size; ++i )
+        keys[ i ] = i;
+
+    ASSERT_EQ( bpt.insert_presorted( keys ), keys.size() );
+
+    auto const stale_separator_old_key{ max_per_node };
+    auto const stale_separator_new_key{ stale_separator_old_key + offset };
+    ASSERT_EQ(
+        bpt.replace_keys_inplace(
+            std::array<unsigned, 1>{ stale_separator_old_key },
+            std::array<unsigned, 1>{ stale_separator_new_key }
+        ),
+        1
+    );
+
+    auto const deletions_to_underflow{ static_cast<unsigned>( max_per_node - min_per_node + 1 ) };
+    for ( auto i{ 0U }; i < deletions_to_underflow; ++i ) {
+        auto const key_to_erase{ stale_separator_old_key + 1 + i };
+        SCOPED_TRACE( std::format(
+            "erase iteration={}, key_to_erase={}, stale_separator_old_key={}, stale_separator_new_key={}",
+            i,
+            key_to_erase,
+            stale_separator_old_key,
+            stale_separator_new_key
+        ) );
+        EXPECT_TRUE( bpt.erase( key_to_erase ) );
+    }
+
+    indirect_values.clear();
+#endif
+}
+
 TEST( bp_tree, replace_keys_inplace_single_key )
 {
     using tree_type = psi::vm::bp_tree<unsigned, true, indirect_comparator>;

--- a/test/b+tree.cpp
+++ b/test/b+tree.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <format>
 #include <numeric>
 #include <print>
 #include <random>


### PR DESCRIPTION
… leftmost keys.