### PR TITLE
strided_vector: zero default stride + init→reset + init-policy resize

### DIFF
--- a/include/psi/vm/containers/strided_vector.hpp
+++ b/include/psi/vm/containers/strided_vector.hpp
@@ -508,7 +508,7 @@ public:
     constexpr strided_vector & operator=( strided_vector const & ) = default;
 
     constexpr strided_vector( strided_vector && other ) noexcept( std::is_nothrow_move_constructible_v<backing_vector_type> )
-        : data_  { std::move( other.data_ ) }
+        : data_  { std::move    ( other.data_ ) }
         , stride_{ std::exchange( other.stride_, stride_type{ 0 } ) }
     {}
 
@@ -526,18 +526,34 @@ public:
 
     // Construct `count` default-initialized entries of the given stride
     constexpr strided_vector( stride_type const stride, size_type const count )
-        : data_( static_cast<size_type>( count ) * stride ), stride_{ stride }
-    { BOOST_ASSUME( stride <= MaxStride ); }
+        : data_( static_cast<size_type>( count * stride ) ), stride_{ stride }
+    {
+        BOOST_ASSUME( stride <= MaxStride );
+        BOOST_ASSUME( stride > 0 || count == 0 ); // zero-stride only supported when empty
+    }
 
     // Construct `count` entries initialized from a prototype span
     constexpr strided_vector( stride_type const stride, size_type const count, std::span<T const> const prototype )
         : stride_{ stride }
     {
         BOOST_ASSUME( stride <= MaxStride );
+        BOOST_ASSUME( stride > 0 || count == 0 ); // zero-stride only supported when empty
         BOOST_ASSERT( prototype.size() == stride );
-        data_.reserve( count * stride );
-        for ( size_type i{ 0 }; i < count; ++i ) {
-            data_.append_range( prototype );
+        if constexpr ( std::is_trivially_destructible_v<T> )
+        {
+            // Single reserve-and-resize with no per-slot construction, then
+            // stamp `prototype` into each slot. Avoids N append_range calls.
+            data_.resize( count * stride, no_init );
+            auto * dst{ data_.data() };
+            for ( size_type i{ 0 }; i < count; ++i, dst += stride )
+                std::ranges::copy( prototype, dst );
+        }
+        else
+        {
+            data_.reserve( count * stride );
+            for ( size_type i{ 0 }; i < count; ++i ) {
+                data_.append_range( prototype );
+            }
         }
     }
 
@@ -559,8 +575,11 @@ public:
     // Stride control
     //--------------------------------------------------------------------------
 
-    /// Clears the container and sets a new stride.
-    void init( stride_type const s ) noexcept
+    /// Clears the container and sets a new stride. Idempotent reset: can be
+    /// called repeatedly, can be called on a default-constructed (stride_==0)
+    /// instance. Call-site-wise this replaces both "fresh init" and
+    /// "reconfigure stride" uses — hence the rename from init() to reset().
+    void reset( stride_type const s ) noexcept
     {
         BOOST_ASSUME( s <= MaxStride );
         stride_ = s;
@@ -685,9 +704,19 @@ public:
         BOOST_ASSUME( stride_ >= 1 );
         BOOST_ASSERT( prototype.size() == stride_ );
         data_.clear();
-        data_.reserve( count * stride_ );
-        for ( size_type i{ 0 }; i < count; ++i ) {
-            data_.append_range( prototype );
+        if constexpr ( std::is_trivially_destructible_v<T> )
+        {
+            data_.resize( count * stride_, no_init );
+            auto * dst{ data_.data() };
+            for ( size_type i{ 0 }; i < count; ++i, dst += stride_ )
+                std::ranges::copy( prototype, dst );
+        }
+        else
+        {
+            data_.reserve( count * stride_ );
+            for ( size_type i{ 0 }; i < count; ++i ) {
+                data_.append_range( prototype );
+            }
         }
     }
 
@@ -808,6 +837,15 @@ public:
     /// Resize to `count` entries. New entries are default-initialized.
     void resize( size_type const count ) { data_.resize( count * stride_ ); }
 
+    /// Resize to `count` entries, forwarding init-policy to the backing
+    /// vector (no_init / default_init / value_init — see psi::vm::vector).
+    /// `no_init` requires a trivially-destructible element type; for other
+    /// types use `default_init` or `value_init`, or the span-prototype form.
+    void resize( size_type const count, init_policy auto const initializer )
+    {
+        data_.resize( count * stride_, initializer );
+    }
+
     /// Resize to `count` entries. New entries are filled from `prototype`.
     void resize( size_type const count, std::span<T const> const prototype )
     {
@@ -817,6 +855,18 @@ public:
         if ( count <= old_entries )
         {
             data_.resize( count * stride_ );
+        }
+        else if constexpr ( std::is_trivially_destructible_v<T> )
+        {
+            // Grow in one shot with no per-slot construction, then stamp
+            // `prototype` into the new tail — one reserve + tight copy loop
+            // beats N append_range calls (each re-checks capacity and
+            // increments size).
+            auto const first_new{ old_entries };
+            data_.resize( count * stride_, no_init );
+            auto * dst{ data_.data() + first_new * stride_ };
+            for ( auto i{ first_new }; i < count; ++i, dst += stride_ )
+                std::ranges::copy( prototype, dst );
         }
         else
         {
@@ -874,7 +924,16 @@ private:
     }
 
     backing_vector_type data_;
-    stride_type         stride_{ 1 };
+    // Default stride is 0: the container is in the fully-uninitialized
+    // "scalar/empty" state. A zero-stride strided_vector has size()==0,
+    // capacity()==0, and empty()==true; all mutation methods assert
+    // stride_ >= 1 so callers that want to mutate must first call
+    // reset(stride). This gives callers a sentinel — `numDims()==0` means
+    // "never configured" — which matches what every "is this freshly
+    // constructed?" site in the rama code wanted anyway (the old default
+    // of 1 was a silent foot-gun; see hemofarm regression, psi.vm commit
+    // c7a35c1's follow-ups).
+    stride_type         stride_{ 0 };
 }; // class strided_vector
 
 //------------------------------------------------------------------------------

--- a/include/psi/vm/containers/vector.hpp
+++ b/include/psi/vm/containers/vector.hpp
@@ -555,11 +555,22 @@ public:
     //! <b>Throws</b>: If memory allocation throws, or T's copy/move constructor throws.
     //!
     //! <b>Complexity</b>: Linear to the difference between this->size() and new_size.
-    template <typename Initializer>
-    void resize( size_type const new_size, Initializer && initializer )
+    void resize( size_type const new_size, init_policy auto const initializer )
     {
-        if ( new_size > this->size() )   grow_to( new_size, std::forward<Initializer>( initializer ) );
-        else                           shrink_to( new_size                                           );
+        if ( new_size > this->size() )   grow_to( new_size, initializer );
+        else                           shrink_to( new_size              );
+    }
+
+    // Value-fill overload: new entries get constructed from `default_value`.
+    // Kept as a separate overload — constrained on `constructible_from` —
+    // so the init-policy tag path is the privileged resolution (a bare
+    // tag can't accidentally bind to this value-fill form).
+    template <typename U>
+    requires( !init_policy<std::remove_cvref_t<U>> && std::constructible_from<value_type, U> )
+    void resize( size_type const new_size, U && default_value )
+    {
+        if ( new_size > this->size() )   grow_to( new_size, std::forward<U>( default_value ) );
+        else                           shrink_to( new_size                                   );
     }
 
     void shrink_to_fit( ) noexcept { this->storage_shrink_to( this->size() ); }

--- a/test/strided_vector.cpp
+++ b/test/strided_vector.cpp
@@ -76,8 +76,8 @@ TYPED_TEST( strided_vector_compliance, default_constructor )
 {
     TypeParam v;
     EXPECT_TRUE( v.empty() );
-    EXPECT_EQ  ( v.size (), 0u );
-    EXPECT_EQ  ( v.stride(), 1u ); // default stride is 1, never 0
+    EXPECT_EQ  ( v.size  (), 0u );
+    EXPECT_EQ  ( v.stride(), 0u ); // default stride is the zero sentinel — "fresh / unconfigured"
 }
 
 TYPED_TEST( strided_vector_compliance, stride_constructor )
@@ -231,8 +231,8 @@ TYPED_TEST( strided_vector_compliance, moved_from_is_reusable_via_init )
     a.push_back( as_span( make_entry<TypeParam>( { 7, 8 } ) ) );
     TypeParam b{ std::move( a ) };
     // After move, source's stride is 0 (sentinel for fresh/uninitialised).
-    // init() re-arms it for reuse, same flow as on a default-constructed one.
-    a.init( 3 );
+    // reset() re-arms it for reuse, same flow as on a default-constructed one.
+    a.reset( 3 );
     EXPECT_EQ  ( a.stride(), 3u );
     EXPECT_TRUE( a.empty() );
     a.push_back( as_span( make_entry<TypeParam>( { 1, 2, 3 } ) ) );
@@ -332,15 +332,18 @@ TYPED_TEST( strided_vector_compliance, assign_range_of_entries )
 // 2. Capacity
 ////////////////////////////////////////////////////////////////////////////////
 
-TYPED_TEST( strided_vector_compliance, init_sets_stride_and_resets )
+TYPED_TEST( strided_vector_compliance, reset_sets_stride_and_clears )
 {
     TypeParam v;
-    v.init( 3 );
+    // Default-constructed: stride is the zero sentinel (fresh / unconfigured).
+    EXPECT_EQ  ( v.stride(), 0u );
+    EXPECT_TRUE( v.empty ()     );
+    v.reset( 3 );
     EXPECT_EQ  ( v.stride(), 3u );
     EXPECT_TRUE( v.empty ()     );
     v.push_back( as_span( make_entry<TypeParam>( { 1, 2, 3 } ) ) );
     EXPECT_EQ( v.size(), 1u );
-    v.init( 2 );
+    v.reset( 2 );
     EXPECT_EQ  ( v.stride(), 2u );
     EXPECT_TRUE( v.empty ()     );
 }


### PR DESCRIPTION
## Summary

Three-part cleanup of \`strided_vector\` motivated by a live bug in a downstream user (rama hemofarm \`UPDATE_CELLS\` crash, worked around at the call site with a mapping-based sentinel; see farseerdev/rama commit \`aa561ccf\`). Root-cause fix here + a couple of API polishes:

- **Default \`stride_\` is now 0, not 1.** A default-constructed \`strided_vector\` is in the fully-unconfigured state: \`size() == 0\`, \`capacity() == 0\`, \`stride() == 0\`, \`empty() == true\`. All mutation methods continue to assert \`stride_ >= 1\`, so the first \`reset(stride)\` call before any \`push_back\` is mandatory — same contract as before, just without the silent default-1-stride foot-gun. Callers that treat \`v.stride() == 0\` as a \"fresh / never configured\" sentinel finally get a reliable answer.

- **\`init(stride)\` → \`reset(stride)\`.** Idempotent: callable on a default-constructed or a populated instance. \"init\" read like a constructor when it's really a reset; the new name matches what the method does.

- **New \`resize(count, init_policy)\` overload.** Forwards \`no_init\` / \`default_init\` / \`value_init\` (the same tags \`psi::vm::vector\` already supports) to the backing vector. Lets callers skip zero-fill for trivially-destructible types.

- **Internal use of \`resize(no_init) + stamp loop\` for trivially-destructible \`T\`** in three prototype-fill hot paths:
  - \`strided_vector(stride, count, prototype)\` constructor
  - \`assign(count, prototype)\`
  - \`resize(count, prototype)\`
  The previous shape — \`reserve + N × append_range\` — has the backing vector re-check capacity each iteration; the new shape is one resize plus a tight inline copy loop. Non-trivial \`T\` keeps the \`append_range\` fallback (can't \`resize(no_init)\` non-trivial types).

## Test plan

- [x] \`strided_vector_compliance\` typed suite (6 type instantiations × 68 cases = 408 tests) passes.
- [x] Compliance-test updates:
  - \`default_constructor\` now expects \`stride() == 0\`.
  - \`init_sets_stride_and_resets\` → \`reset_sets_stride_and_clears\`, plus the post-move re-arm test's comment/method.
- [x] Downstream (rama) compile + sanity: 410/410 on \`db.load\` + \`strided_vector_*\` + \`*subspace*\` filters, DevRelease.

## Downstream follow-ups (rama)

Paired with farseerdev/rama commit \`566ee162\` which:

1. Bumps the submodule to this branch's tip.
2. Propagates \`init → reset\` at every direct \`strided_vector\` call site (wrapper types keep their own \`init\` entry-points — only the wrappers' internal strided_vector calls change).
3. Simplifies the \`aa561ccf\` workaround back to the natural \`numDims() == 0\` sentinel now that the underlying foot-gun is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)