### PR TITLE
b+tree: mark_dirty after bulk_insert_prepare populates leaves

### DIFF
--- a/include/psi/vm/containers/b+tree.hpp
+++ b/include/psi/vm/containers/b+tree.hpp
@@ -1227,6 +1227,12 @@ protected: // 'other'
                 std::copy_n ( p_keys, size_to_copy, leaf.keys );
                 std::advance( p_keys, size_to_copy );
                 leaf.num_vals  = size_to_copy;
+                // The leaf is being pulled directly off the free list (not via
+                // new_node()), so its persisted dirty bit is whatever the prior
+                // commit_to left behind — typically clean. Without re-marking,
+                // the next commit_to would skip this freshly-populated leaf and
+                // leave stale bytes in master, blowing up later tree walks.
+                leaf.mark_dirty();
                 count         += size_to_copy;
                 *p_node++      = &leaf;
                 BOOST_ASSUME( hdr().free_node_count_ ); // manual/local free node accounting

--- a/test/cow.cpp
+++ b/test/cow.cpp
@@ -888,6 +888,92 @@ TEST( bptree_cow, commit_bulk_erase )
 #endif
 }
 
+TEST( bptree_cow, commit_bulk_insert_reuses_freed_leaves )
+{
+    // Regression test for missing mark_dirty() in bulk_insert_prepare's
+    // free-list reuse path.
+    //
+    // Sequence that exposes the bug:
+    //   1. Populate src with N keys (allocates several leaves).
+    //   2. COW clone + erase a contiguous range so multiple whole leaves
+    //      get freed; commit back so src ends up with a non-empty free
+    //      list whose nodes are clean from the master's point of view.
+    //   3. COW clone again + bulk-insert keys via the sized-range insert
+    //      overload. bulk_insert_prepare's `can_preallocate` branch then
+    //      walks the free list directly (no `new_node()` call) and fills
+    //      the freed leaves with new keys. Before the fix it did NOT call
+    //      mark_dirty() on those populated leaves.
+    //   4. commit_to: selective dirty-node copy skips the populated leaves
+    //      (their dirty bit was left at the post-erase clean state from
+    //      the master) and src never receives the new key bytes.
+    //   5. Reading src would then return wrong contents — `has()` for the
+    //      inserted keys would fail, and tree walks could even hit stale
+    //      bytes left over from the freed nodes.
+    //
+    // To stress the bug, the inserted batch must span multiple leaves so
+    // the middle ones (which no incidental mark_dirty path reaches) are
+    // exercised, not just the head/tail.
+    bptree_set<int> src;
+    src.map_memory();
+
+    auto constexpr N        { 4000 };
+    auto constexpr erase_lo { 500  };
+    auto constexpr erased   { 1500 };
+    auto constexpr erase_hi { erase_lo + erased }; // 2000
+    auto constexpr inserts  { 1500 }; // disjoint keys [N..N+inserts)
+    static_assert( erase_hi <= N );
+
+    {
+        std::vector<int> values( N );
+        std::iota( values.begin(), values.end(), 0 );
+        src.insert( values );
+    }
+    ASSERT_EQ( src.size(), static_cast<std::size_t>( N ) );
+
+    // Step 2: drop a contiguous middle range so several whole leaves end up
+    // on src's free list after the commit.
+    {
+        bptree_set<int> clone{ src };
+        std::vector<int> to_erase( erased );
+        std::iota( to_erase.begin(), to_erase.end(), erase_lo );
+        clone.erase_sorted( to_erase );
+        ASSERT_EQ( clone.size(), static_cast<std::size_t>( N - erased ) );
+        clone.commit_to( src );
+    }
+    ASSERT_EQ( src.size(), static_cast<std::size_t>( N - erased ) );
+
+    // Step 3+4: bulk-insert a sized range so bulk_insert_prepare takes the
+    // can_preallocate branch and pulls leaves straight off src's free list.
+    {
+        bptree_set<int> clone{ src };
+        std::vector<int> to_insert( inserts );
+        std::iota( to_insert.begin(), to_insert.end(), N );
+        EXPECT_EQ( clone.insert( to_insert ), static_cast<std::size_t>( inserts ) );
+        ASSERT_EQ( clone.size(), static_cast<std::size_t>( N - erased + inserts ) );
+        clone.commit_to( src );
+    }
+
+    // Step 5: every freshly inserted key must be visible in src.  Before the
+    // fix, leaves drawn from the free list were populated but not marked
+    // dirty, so commit_to skipped them and these lookups would fail
+    // (or worse, blow up while traversing stale free-list bytes).
+    EXPECT_EQ( src.size(), static_cast<std::size_t>( N - erased + inserts ) );
+    for ( int k{ N }; k < N + inserts; ++k )
+    {
+        EXPECT_TRUE( has( src, k ) ) << "missing inserted key " << k;
+    }
+    // Surviving keys from the initial population are untouched.
+    EXPECT_TRUE ( has( src, 0              ) );
+    EXPECT_TRUE ( has( src, erase_lo - 1   ) );
+    EXPECT_TRUE ( has( src, erase_hi       ) );
+    EXPECT_TRUE ( has( src, N - 1          ) );
+    EXPECT_FALSE( has( src, erase_lo       ) );
+    EXPECT_FALSE( has( src, erase_hi - 1   ) );
+#if !__SANITIZE_ADDRESS__
+    EXPECT_TRUE( std::ranges::is_sorted( src, src.comp() ) );
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // COW expand test: clone a b+tree, grow it (trigger mapped_view::expand on the
 // COW view), verify both source and clone are intact.


### PR DESCRIPTION
## Summary

`bulk_insert_prepare`'s `can_preallocate` branch walks the free list
directly (via `hdr().free_list_` + `leaf.right`) and fills the
returned leaves with keys/values without going through `new_node()`
— so no path marks those leaves dirty.

After selective `commit_to` (`baa20d4`), only dirty nodes are written
into the target. Free-list leaves carry whatever dirty bit they had
when the previous transaction's `commit_to` finished — typically
clean — so the bytes populated by `bulk_insert_prepare` never reach
the target mapping. A subsequent transaction's tree walk then reads
stale contents and crashes (or silently returns wrong results).

## Why only the `can_preallocate` branch

The `!can_preallocate` fallback path is already safe: every leaf it
populates comes from `new_node<leaf_node>()` (first leaf at line
1215, subsequent leaves at line 1273). `bptree_base::new_node()`
already calls `mark_dirty()` in both its free-list-reuse
(`b+tree.cpp:555`) and fresh-allocation (`b+tree.cpp:562`) paths,
so leaves emerging from that branch are dirty before population
even begins.

Earlier revisions of this PR added a defensive `mark_dirty()` to
that branch too — dropped, per Copilot review feedback.

## Test

Adds `bptree_cow.commit_bulk_insert_reuses_freed_leaves` to
`test/cow.cpp`, modelled on the existing `commit_bulk_erase`
regression. The sequence:

1. Populate a tree with N keys.
2. Clone + bulk-erase a contiguous middle range; commit back so
   several whole leaves land on the source's free list.
3. Clone again + bulk-insert a sized range of disjoint keys —
   `bulk_insert_prepare`'s `can_preallocate` branch walks the free
   list and fills the freed leaves with the new keys.
4. `commit_to` the source.
5. Assert every inserted key is visible in the source and the tree
   is still sorted.

Without the fix, step 5 fails because the populated leaves are not
marked dirty and `commit_to` skips them, leaving the source holding
stale (freed) bytes at those slots.

The batch in step 3 is sized to span multiple leaves so the middle
leaves — which no incidental `mark_dirty` path reaches in the
post-prepare pipeline — are also exercised.