### PR TITLE
Debug-poison no_init storage (0xCD); don't guarantee in-place CRT shrink under ASan/PageHeap

### DIFF
--- a/include/psi/vm/allocators/crt.hpp
+++ b/include/psi/vm/allocators/crt.hpp
@@ -248,7 +248,23 @@ struct crt_allocator
     // _expand works in-place for shrink, but only on non-aligned (regular malloc)
     // allocations. Callers with alignment > guaranteed_alignment must use shrink_to.
 #ifdef _MSC_VER
+#   if defined( __SANITIZE_ADDRESS__ ) || ( defined( __has_feature ) && __has_feature( address_sanitizer ) ) || defined( PSI_VM_NO_INPLACE_SHRINK )
+    // AddressSanitizer intercepts the CRT _expand and does NOT honor in-place
+    // shrink (its interceptor reports failure), which trips the BOOST_VERIFY in
+    // heap_storage::storage_shrink_to. Report shrink as non-guaranteed under ASan
+    // so the container falls back to the realloc shrink path. (The GROW path via
+    // try_expand already tolerates failure -> relocate_to, so only the shrink
+    // guarantee needs the carve-out; in_place_ops_require_default_alignment stays
+    // true because _expand is UB on _aligned_malloc'd blocks regardless of ASan.)
+    // PSI_VM_NO_INPLACE_SHRINK: opt-in carve-out for consumers running the plain
+    // system CRT (no mi/je override) under full PageHeap / Application Verifier —
+    // there _expand(ptr, 0) (an empty-container shrink_to_fit) is routed through
+    // _aligned_offset_malloc(0) -> _invalid_parameter -> abort; the realloc shrink
+    // path (realloc(ptr,0) == free) is instrumentation-safe.
+    static constexpr bool guaranteed_in_place_shrink{ false };
+#   else
     static constexpr bool guaranteed_in_place_shrink{ true };
+#   endif
     // True: _expand only works on regular malloc allocations (not _aligned_malloc).
     // Callers must not call try_expand / try_shrink_in_place when alignment > guaranteed.
     static constexpr bool in_place_ops_require_default_alignment{ true };

--- a/include/psi/vm/allocators/crt.hpp
+++ b/include/psi/vm/allocators/crt.hpp
@@ -247,8 +247,17 @@ struct crt_allocator
     static constexpr bool try_expand_supports_null  { false }; // _expand(nullptr) is UB
     // _expand works in-place for shrink, but only on non-aligned (regular malloc)
     // allocations. Callers with alignment > guaranteed_alignment must use shrink_to.
+// __has_feature is a Clang builtin; MSVC's (cl.exe) preprocessor errors on a bare
+// __has_feature(...) token inside #if even when guarded by defined(__has_feature)
+// (it does not short-circuit the parse). Funnel it through a macro so cl.exe never
+// sees the call; clang-cl (which also defines _MSC_VER) still resolves it.
+#if defined( __has_feature )
+#   define PSI_VM_DETAIL_ASAN_ENABLED __has_feature( address_sanitizer )
+#else
+#   define PSI_VM_DETAIL_ASAN_ENABLED 0
+#endif
 #ifdef _MSC_VER
-#   if defined( __SANITIZE_ADDRESS__ ) || ( defined( __has_feature ) && __has_feature( address_sanitizer ) ) || defined( PSI_VM_NO_INPLACE_SHRINK )
+#   if defined( __SANITIZE_ADDRESS__ ) || PSI_VM_DETAIL_ASAN_ENABLED || defined( PSI_VM_NO_INPLACE_SHRINK )
     // AddressSanitizer intercepts the CRT _expand and does NOT honor in-place
     // shrink (its interceptor reports failure), which trips the BOOST_VERIFY in
     // heap_storage::storage_shrink_to. Report shrink as non-guaranteed under ASan

--- a/include/psi/vm/containers/vector.hpp
+++ b/include/psi/vm/containers/vector.hpp
@@ -263,11 +263,38 @@ private:
         return { const_cast<vector &>( *this ).make_iterator( offset ) };
     }
 
+    // Permanent debug poison (MSVC-debug-heap style). Fills freshly-acquired
+    // `no_init` element storage with 0xCD so a read-before-write surfaces as an
+    // obviously-wild value (0xCDCDCDCD as an index ~= 3.45e9 -> wild store; as a
+    // pointer -> unmapped) AT the misuse site, instead of silently inheriting
+    // heap garbage that only intermittently corrupts a neighbour allocation.
+    // Guards:
+    //   - !storage_zero_initialized: zero-init (VM/mmap) storage carries no
+    //     garbage AND value_init relies on its zero-promise -> never poison it.
+    //   - is_trivially_copyable: only raw POD element storage; non-trivial types
+    //     get proper construction over this region anyway.
+    //   - runtime only (skipped during constant evaluation).
+    // 0xCD (not 0xFF) deliberately avoids colliding with the -1 / SIZE_MAX /
+    // calc_na-style sentinels that are frequently valid values.
+    static constexpr void poison_no_init( [[ maybe_unused ]] value_type * const first, [[ maybe_unused ]] size_type const count ) noexcept
+    {
+#   ifndef NDEBUG
+        if constexpr ( std::is_trivially_copyable_v<value_type> && !storage_t::storage_zero_initialized )
+        {
+            if ( count && !std::is_constant_evaluated() )
+            {
+                std::memset( static_cast<void *>( first ), 0xCD, static_cast<std::size_t>( count ) * sizeof( value_type ) );
+            }
+        }
+#   endif
+    }
+
     // constructor helpers - for initializing the vector during construction
     constexpr void initialized_impl( size_type const initial_size, no_init_t ) noexcept
     {
         storage_t::storage_init( initial_size );
         BOOST_ASSUME( this->size() == initial_size );
+        poison_no_init( this->data(), initial_size );
     }
 
     // GCC 15.2.1 bug: when a base-class constructor inherited via
@@ -1059,7 +1086,13 @@ public:
 
     // Explicit sizing: always exact-fit (no geometric headroom).
     // Append operations (emplace_back) use storage_grow_to() with Growth instead.
-    value_type * grow_to( size_type const target_size, no_init_t ) { return storage_t::template storage_grow_to<geometric_growth{ 1, 1 }>( target_size ); }
+    value_type * grow_to( size_type const target_size, no_init_t )
+    {
+        auto const old_size{ this->size() };
+        auto const p{ storage_t::template storage_grow_to<geometric_growth{ 1, 1 }>( target_size ) };
+        if ( target_size > old_size ) { poison_no_init( p + old_size, target_size - old_size ); }
+        return p;
+    }
     value_type * grow_to( size_type const target_size, default_init_t )
     {
         auto const current_size{ this->size() };


### PR DESCRIPTION
Two related container/allocator debug-hardening changes (two commits).

## 1. `vector`: debug-poison `no_init` element storage with `0xCD`
Permanent `!NDEBUG` hardening (MSVC-debug-heap style). Freshly-acquired `no_init` element storage is filled with `0xCD` so a read-before-write surfaces as an obviously-wild value (`0xCDCDCDCD` as an index ≈ 3.45e9 → wild store; as a pointer → unmapped) **at the misuse site**, instead of silently inheriting heap garbage that only intermittently corrupts a neighbouring allocation.

Wired into both `no_init` acquisition points (`initialized_impl`, `grow_to`). Guarded to:
- `!storage_zero_initialized` only — heap/fixed/sbo carry garbage; VM/mmap is zero and `value_init` relies on that zero-promise, so it is never poisoned.
- trivially-copyable element types only.
- runtime only (skipped during constant evaluation).

`0xCD` (not `0xFF`) deliberately avoids colliding with the `-1` / `SIZE_MAX` / sentinel values that are frequently valid.

## 2. `crt_allocator`: don't guarantee in-place shrink under ASan / instrumented allocators
`try_shrink_in_place` uses `::_expand`, which only shrinks in-place on regular (non-aligned) CRT-malloc blocks. Two environments break that promise:
- AddressSanitizer intercepts `_expand` and reports in-place shrink as failed → the `BOOST_VERIFY` in `heap_storage::storage_shrink_to` fires.
- Windows full PageHeap routes `_expand(ptr, 0)` (empty-container `shrink_to_fit`) through `_aligned_offset_malloc(0)` → `_invalid_parameter` → abort.

Reports `guaranteed_in_place_shrink=false` under `__SANITIZE_ADDRESS__` / `__has_feature(address_sanitizer)` or the opt-in `PSI_VM_NO_INPLACE_SHRINK`, so the container falls back to the realloc shrink path (`realloc(ptr,0) == free`), which is instrumentation-safe. The grow path via `try_expand` already tolerates failure (relocate_to), so only the shrink guarantee needs the carve-out.

Validated downstream (rama): DevRelease builds + full unit suite passes with the poison active; the ASan build links + runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)