### PR TITLE
fix(vector): insert-fill must construct (not assign) into relocated slots

### DIFF
--- a/include/psi/vm/containers/vector.hpp
+++ b/include/psi/vm/containers/vector.hpp
@@ -800,7 +800,18 @@ public:
             }
         }
         auto const iter{ make_space_for_insert( position, 1 ) };
-        if constexpr ( trivially_destructible_after_move_assignment<value_type> )
+        // Placement-construct vs assign into the made-room slot, matching the
+        // state shift_elements_right left it in:
+        //   * is_trivially_moveable        => memmove => RAW byte-duplicate slot
+        //     => MUST construct (assign would run the moved-out type's destructor
+        //     on the duplicate and free the relocated element's resources — a UAF;
+        //     e.g. a std::variant with a std::vector alternative that is
+        //     is_trivially_moveable yet whose move-assign is not noexcept, so it is
+        //     NOT trivially_destructible_after_move).
+        //   * else (element-move)          => moved-from HUSK slot => constructing
+        //     over it (skipping its dtor) is safe iff that dtor is elidable, i.e.
+        //     trivially_destructible_after_move; otherwise assign.
+        if constexpr ( is_trivially_moveable<value_type> || trivially_destructible_after_move_assignment<value_type> )
             construct_at( *iter, std::forward<Args>( args )... );
         else
             *iter = { std::forward<Args>( args )... };
@@ -863,7 +874,7 @@ public:
     iterator insert( const_iterator const position, size_type const n, param_const_ref x )
     {
         auto const iter{ make_space_for_insert( position, n ) };
-        if constexpr ( trivially_destructible_after_move_assignment<value_type> )
+        if constexpr ( is_trivially_moveable<value_type> || trivially_destructible_after_move_assignment<value_type> ) // see emplace()
             std::uninitialized_fill_n( iter, n, x );
         else
             std::fill_n( iter, n, x );
@@ -885,7 +896,7 @@ public:
     {
         auto const n{ static_cast<size_type>( std::distance( first, last ) ) };
         auto const iter{ make_space_for_insert( position, n ) };
-        if constexpr ( trivially_destructible_after_move_assignment<value_type> )
+        if constexpr ( is_trivially_moveable<value_type> || trivially_destructible_after_move_assignment<value_type> ) // see emplace()
             std::uninitialized_copy_n( first, n, iter );
         else
             std::copy_n( first, n, iter );
@@ -913,14 +924,14 @@ public:
             auto const iter{ make_space_for_insert( position, n ) };
             if constexpr ( std::is_rvalue_reference_v<Rng &&> )
             {
-                if constexpr ( trivially_destructible_after_move_assignment<value_type> )
+                if constexpr ( is_trivially_moveable<value_type> || trivially_destructible_after_move_assignment<value_type> ) // see emplace()
                     std::ranges::uninitialized_move( std::ranges::begin( rng ), std::ranges::end( rng ), iter, std::unreachable_sentinel );
                 else
                     std::ranges::move( rng, iter );
             }
             else
             {
-                if constexpr ( trivially_destructible_after_move_assignment<value_type> )
+                if constexpr ( is_trivially_moveable<value_type> || trivially_destructible_after_move_assignment<value_type> ) // see emplace()
                     std::uninitialized_copy( std::ranges::begin( rng ), std::ranges::end( rng ), iter );
                 else
                     std::ranges::copy( rng, iter );

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -63,6 +63,57 @@ TEST( vector_traits, heap_vector_variant_growth_preserves_values )
     }
 }
 
+// Regression: middle-insert relocation must not free a relocated element's
+// owned heap buffer. The insert-shift (shift_elements_right) chooses
+// memmove-vs-element-move on is_trivially_moveable<T>; the made-room slot must
+// then be filled with the SAME discriminator. A type that is is_trivially_moveable
+// (memmove relocation valid) yet NOT trivially_destructible_after_move_assignment
+// (non-noexcept move-assignment) used to take the memmove shift path (slot left a
+// raw byte-duplicate) but the assign fill path (`*iter = {...}`), whose move-assign
+// destructor ran on the stale duplicate and freed the relocated element's buffer
+// -> use-after-free. (Real-world trigger: psi::vm::flat_map<string, ast::QueryFilter>
+//  where QueryFilter is a std::variant with a heap_vector alternative.)
+namespace {
+    inline std::atomic<int> reloc_owner_net_allocs{ 0 };
+    struct reloc_heap_owner {
+        int * p{ nullptr };
+        reloc_heap_owner() noexcept = default;
+        reloc_heap_owner( int const v ) : p{ new int{ v } } { ++reloc_owner_net_allocs; }
+        reloc_heap_owner( reloc_heap_owner && o ) noexcept : p{ o.p } { o.p = nullptr; } // genuine move (nulls source)
+        reloc_heap_owner & operator=( reloc_heap_owner && o ) noexcept( false ) // NOT noexcept -> not trivially_destructible_after_move
+        {
+            if ( this != &o ) { reset(); p = o.p; o.p = nullptr; }
+            return *this;
+        }
+        reloc_heap_owner( reloc_heap_owner const & ) = delete;
+        reloc_heap_owner & operator=( reloc_heap_owner const & ) = delete;
+        ~reloc_heap_owner() noexcept { reset(); }
+        void reset() noexcept { if ( p ) { delete p; p = nullptr; --reloc_owner_net_allocs; } }
+        // memcpy-relocation is valid (just a pointer); force the classification
+        // the way a variant-with-heap-member ends up is_trivially_moveable == true.
+        static constexpr bool is_trivially_moveable = true;
+    };
+}
+
+TEST( vector_insert, middle_insert_relocates_heap_owner_without_uaf )
+{
+    using T = reloc_heap_owner;
+    static_assert(  is_trivially_moveable<T> );                          // memmove shift path
+    static_assert( !trivially_destructible_after_move_assignment<T> );   // assign fill path -> the mismatch
+
+    reloc_owner_net_allocs.store( 0 );
+    {
+        heap_vector<T, std::uint32_t> v;
+        v.emplace_back( 100 );                  // [0] = 100
+        v.emplace( v.begin(), 200 );            // shift [0]->[1], place 200 at [0]
+        ASSERT_EQ( v.size(), 2U );
+        EXPECT_EQ( *v[ 0 ].p, 200 );
+        ASSERT_NE( v[ 1 ].p, nullptr );         // freed by the bug (move-assign over memmove'd stale dup)
+        EXPECT_EQ( *v[ 1 ].p, 100 );            // UAF read under the bug (ASAN traps)
+    }
+    EXPECT_EQ( reloc_owner_net_allocs.load(), 0 ); // bug double-frees -> ends negative
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Typed test suite -- runs every test against all vector types
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Bug: heap use-after-free relocating elements on middle-insert

`vector` insert (`emplace` / `insert` / `insert_range`) makes room via
`shift_elements_right`, which picks its relocation strategy on
`is_trivially_moveable<T>`:

* **trivially moveable** → `memmove` → the made-room slot is a **raw byte-duplicate** of the relocated element (its resource handle now aliased by two slots);
* **otherwise** → element-move → the made-room slot is a **moved-from husk**.

The five fill sites then chose *placement-construct vs move-assign* on a **different** trait — `trivially_destructible_after_move_assignment<T>`. When the two traits disagree, the fill and the shift disagree about the slot's state.

For a type that **is** `is_trivially_moveable` but is **not** `trivially_destructible_after_move` — e.g. a `std::variant` with a `std::vector` alternative, whose move-assignment MSVC reports `noexcept(false)` — the shift `memmove`d (raw slot) but the fill did `*iter = {...}`, a **move-assignment whose destructor ran on the stale byte-duplicate and freed the buffer the relocated element now owns** → heap use-after-free. (Found in production via a `std::vector`-backed flat_map of such a variant: a middle-insert of a key that sorts before an existing one shifted the existing element and freed its child buffer, leaving a dangling AST reference.)

## Fix

Gate the fill on the **same** condition the slot state depends on:

```cpp
construct iff ( is_trivially_moveable<T> || trivially_destructible_after_move_assignment<T> )
```

* `is_trivially_moveable` → memmove → raw slot → **must** construct (assign = UAF);
* else `trivially_destructible_after_move` → husk whose dtor is elidable → construct is safe (and cheaper);
* else → husk needing destruction → assign.

This is a strict **superset** of the previous (`TD`-only) construct set — it only *adds* the trivially-moveable types that were the bug, and is identical to the old behaviour for `!is_trivially_moveable`, so it does **not** pessimize the husk path.

## Test

`test/vector.cpp` → `vector_insert.middle_insert_relocates_heap_owner_without_uaf`: a heap-owning type that is `is_trivially_moveable` but not `trivially_destructible_after_move` (non-`noexcept` move-assign), middle-inserted to force the relocation. Trips `heap-use-after-free` under ASan on the old code; passes with the fix. A net-allocation counter makes it deterministic even without ASan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
