### PR TITLE
feat(vector): support_incomplete_types for recursive strong-typedefs

### DIFF
--- a/include/psi/vm/containers/abi.hpp
+++ b/include/psi/vm/containers/abi.hpp
@@ -2,6 +2,8 @@
 
 #include <psi/build/disable_warnings.hpp>
 
+#include <psi/vm/containers/complete.hpp>
+
 #include <boost/config.hpp>
 
 #include <span>
@@ -29,19 +31,21 @@ PSI_WARNING_MSVC_DISABLE( 5030 ) // unrecognized attribute
 template <typename T>
 bool constexpr can_be_passed_in_reg
 {
-    (
-        std::is_trivial_v<T> &&
-        ( sizeof( T ) <= 2 * sizeof( void * ) ) // assuming a sane ABI like SysV (ignoring the MS x64 disaster)
-    )
+    complete<T> && (
+        (
+            std::is_trivial_v<T> &&
+            ( sizeof( T ) <= 2 * sizeof( void * ) ) // assuming a sane ABI like SysV (ignoring the MS x64 disaster)
+        )
 #if defined( __GNUC__ ) || defined( __clang__ )
-    || // detect SIMD types (this could also produce false positives for large compiler-native vectors that do not fit into the register file)
-    requires{ __builtin_convertvector( T{}, T ); }
+        || // detect SIMD types (this could also produce false positives for large compiler-native vectors that do not fit into the register file)
+        requires{ __builtin_convertvector( T{}, T ); }
 #endif
-    // This is certainly not an exhaustive list/'trait' - certain types that can
-    // be passed in reg cannot be detected as such by existing compiler
-    // functionality, e.g. Homogeneous Vector Aggregates
-    // https://devblogs.microsoft.com/cppblog/introducing-vector-calling-convention
-    // users are encouraged to provide specializations for such types.
+        // This is certainly not an exhaustive list/'trait' - certain types that can
+        // be passed in reg cannot be detected as such by existing compiler
+        // functionality, e.g. Homogeneous Vector Aggregates
+        // https://devblogs.microsoft.com/cppblog/introducing-vector-calling-convention
+        // users are encouraged to provide specializations for such types.
+    )
 }; // can_be_passed_in_reg
 
 template <typename T>

--- a/include/psi/vm/containers/complete.hpp
+++ b/include/psi/vm/containers/complete.hpp
@@ -1,0 +1,15 @@
+#pragma once
+//------------------------------------------------------------------------------
+namespace psi::vm
+{
+//------------------------------------------------------------------------------
+
+// True when T is a complete object type. Use to guard type-trait builtins and
+// sizeof in headers that must tolerate forward-declared value_types (e.g.
+// vector<heap_storage<Rec>> while Rec is still being defined).
+template <typename T>
+concept complete = sizeof( T ) >= 0 || false;
+
+//------------------------------------------------------------------------------
+} // namespace psi::vm
+//------------------------------------------------------------------------------

--- a/include/psi/vm/containers/heap_vector.hpp
+++ b/include/psi/vm/containers/heap_vector.hpp
@@ -30,8 +30,8 @@ namespace psi::vm
 // heap_vector<T, sz_t, options, growth> = vector<heap_storage<T, sz_t, void, options>, growth>
 // The 'void' Allocator default auto-computes to crt_allocator with correct alignment.
 // Growth policy lives at the vector<> level, not inside storage.
-template <typename T, typename sz_t = std::size_t, heap_options options = {}, geometric_growth growth = {}>
-using heap_vector = vector<heap_storage<T, sz_t, void, options>, growth>;
+template <typename T, typename sz_t = std::size_t, heap_options options = {}, geometric_growth growth = {}, bool support_incomplete_types = false>
+using heap_vector = vector<heap_storage<T, sz_t, void, options>, growth, support_incomplete_types>;
 
 // Generic erase_if / erase are provided in vector.hpp for all psi_vm_vector types.
 

--- a/include/psi/vm/containers/is_trivially_moveable.hpp
+++ b/include/psi/vm/containers/is_trivially_moveable.hpp
@@ -15,6 +15,8 @@
 
 #include <psi/build/disable_warnings.hpp>
 
+#include <psi/vm/containers/complete.hpp>
+
 #include <type_traits>
 //------------------------------------------------------------------------------
 namespace std
@@ -104,7 +106,13 @@ namespace psi::vm
 
 PSI_WARNING_DISABLE_PUSH()
 PSI_WARNING_CLANG_DISABLE( -Wdeprecated-builtins )
-// allowed/expected to be user-specialized for custom types
+// allowed/expected to be user-specialized for custom types.
+// NB: like the standard relocatability traits, this requires a complete T (the
+// builtins below are ill-formed for incomplete types). Incomplete-value_type
+// tolerance is a property of the *container* (vector's support_incomplete_types
+// template parameter routes around any class-scope query of this trait), not of
+// this trait itself — keeping the trait a pure function of a complete type
+// avoids the ODR hazard of a value that silently flips with completeness.
 template <typename T>
 bool constexpr is_trivially_moveable
 {
@@ -122,9 +130,6 @@ bool constexpr is_trivially_moveable
     std::is_trivially_move_constructible_v<T> // beyond P2786 optimistic heuristic https://github.com/psiha/vm/pull/34#discussion_r1914536293
 }; // is_trivially_moveable
 PSI_WARNING_DISABLE_POP()
-
-template <typename T>
-concept complete = sizeof( T ) >= 0 || false;
 
 template <typename T>
 requires complete<T> and requires{ T::is_trivially_moveable; }

--- a/include/psi/vm/containers/storage/heap.hpp
+++ b/include/psi/vm/containers/storage/heap.hpp
@@ -28,12 +28,14 @@
 #if PSI_VM_HAS_MIMALLOC
 #   include <psi/vm/allocators/mimalloc.hpp>
 #endif
+#include <psi/vm/containers/complete.hpp>
 #include <psi/vm/containers/growth_policy.hpp>
 #include <psi/vm/containers/is_trivially_moveable.hpp>
 #include <psi/vm/containers/trivially_destructible_after_move.hpp>
 
 #include <boost/assert.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <utility>
 //------------------------------------------------------------------------------
@@ -60,49 +62,96 @@ struct heap_options
 // is carried inline.
 ////////////////////////////////////////////////////////////////////////////////
 
+namespace detail
+{
+#if PSI_VM_HAS_MIMALLOC
+    template <typename sz_t>
+    using heap_shell_allocator = mimalloc_allocator<std::byte, sz_t>;
+#else
+    template <typename sz_t>
+    using heap_shell_allocator = crt_allocator<std::byte, sz_t>;
+#endif
+
+    // Byte-oriented backing allocator for the default (Allocator=void) heap_storage
+    // path.  heap_storage owns a typed T* but allocates through std::byte so
+    // the storage class can instantiate while T is still incomplete (recursive
+    // strong-typedefs); shell_* below bridge element counts/pointers ↔ bytes.
+    // if constexpr — a ternary with alignof(T) is ill-formed for incomplete T even
+    // on the discarded branch (both operands are checked at class-template scope).
+    template <typename U>
+    consteval std::uint8_t heap_default_alignment() noexcept
+    {
+        if constexpr ( complete<U> )
+            return std::uint8_t{ alignof( U ) };
+        else
+            return std::uint8_t{ alignof( std::max_align_t ) };
+    }
+} // namespace detail
+
 template <typename T, typename sz_t = std::size_t, typename Allocator = void, heap_options options = {}>
 class [[ nodiscard, clang::trivial_abi ]] heap_storage
     : private std::conditional_t<
         std::is_void_v<Allocator>,
-#   if PSI_VM_HAS_MIMALLOC
-        mimalloc_allocator<T, sz_t>,
-#   else
-        crt_allocator     <T, sz_t>,
-#   endif
+        detail::heap_shell_allocator<sz_t>,
         Allocator
     >
 {
+    using shell_t = std::conditional_t<std::is_void_v<Allocator>, detail::heap_shell_allocator<sz_t>, Allocator>;
+
 public:
-    static std::uint8_t constexpr alignment{ options.alignment ? options.alignment : std::uint8_t{ alignof( std::conditional_t<complete<T>, T, std::max_align_t> ) } };
+    // Use alignof(T) when T is complete; fall back to max_align_t for incomplete
+    // recursive strong-typedefs so heap_storage<> never touches alignof(T) at class scope.
+    static std::uint8_t constexpr alignment{
+        options.alignment ? options.alignment : detail::heap_default_alignment<T>()
+    };
 
     static bool constexpr storage_zero_initialized{ false };
     static bool constexpr fixed_sized_copy        { false }; // only true for small fixed_storage (MSVC workaround having to define this everywhere)
 
     using size_type      = sz_t;
     using value_type     = T;
+    using pointer        = value_type *;
+    using const_pointer  = value_type const *;
     using allocator_type = std::conditional_t<
         std::is_void_v<Allocator>,
-#   if PSI_VM_HAS_MIMALLOC
-        mimalloc_allocator<T, sz_t>,
-#   else
-        crt_allocator<T, sz_t>,
-#   endif
+        detail::heap_shell_allocator<sz_t>,
         Allocator
     >;
 
 private:
-    using al = allocator_type; // for compile-time trait checks (has_try_expand<al>, al::guaranteed_in_place_shrink, etc.)
+    using al = shell_t; // trait checks (has_try_expand, guaranteed_in_place_shrink, ...)
 
-    // EBO accessor: cast to the allocator base subobject.
-    constexpr allocator_type       & alloc()       noexcept { return static_cast<allocator_type       &>( *this ); }
-    constexpr allocator_type const & alloc() const noexcept { return static_cast<allocator_type const &>( *this ); }
+    [[nodiscard]] static constexpr std::size_t byte_count( size_type const element_count ) noexcept
+    {
+        return static_cast<std::size_t>( element_count ) * sizeof( value_type );
+    }
+
+    [[nodiscard]] static constexpr typename shell_t::size_type shell_byte_count( size_type const element_count ) noexcept
+    {
+        return static_cast<typename shell_t::size_type>( byte_count( element_count ) );
+    }
+
+    constexpr shell_t       & shell()       noexcept { return static_cast<shell_t       &>( *this ); }
+    constexpr shell_t const & shell() const noexcept { return static_cast<shell_t const &>( *this ); }
+
+    // Custom Allocator path: delegate to user allocator (element-count semantics).
+    constexpr allocator_type       & alloc()       noexcept requires ( !std::is_void_v<Allocator> ) { return static_cast<allocator_type       &>( *this ); }
+    constexpr allocator_type const & alloc() const noexcept requires ( !std::is_void_v<Allocator> ) { return static_cast<allocator_type const &>( *this ); }
+
+    // Void-Allocator path: shell_* forward typed element ops to the byte shell (see above).
+    [[ nodiscard ]] pointer shell_allocate( size_type const element_count ) { return reinterpret_cast<pointer>( shell().template allocate<alignment>( shell_byte_count( element_count ) ) ); }
+    void shell_deallocate( pointer const ptr, size_type const element_capacity ) noexcept { shell().template deallocate<alignment>( reinterpret_cast<typename shell_t::pointer>( ptr ), shell_byte_count( element_capacity ) ); }
+    [[ nodiscard ]] pointer shell_grow_to( pointer const ptr, size_type const current_capacity, size_type const target_capacity ) { return reinterpret_cast<pointer>( shell().template grow_to<alignment>( reinterpret_cast<typename shell_t::pointer>( ptr ), shell_byte_count( current_capacity ), shell_byte_count( target_capacity ) ) ); }
+    [[ nodiscard ]] pointer shell_shrink_to( pointer const ptr, size_type const current_size, size_type const target_size ) noexcept { return reinterpret_cast<pointer>( shell().template shrink_to<alignment>( reinterpret_cast<typename shell_t::pointer>( ptr ), shell_byte_count( current_size ), shell_byte_count( target_size ) ) ); }
+    [[ nodiscard ]] size_type shell_capacity( pointer const ptr ) const noexcept { return static_cast<size_type>( shell().size( reinterpret_cast<typename shell_t::const_pointer>( ptr ) ) / sizeof( value_type ) ); }
+    bool shell_try_expand( pointer const ptr, size_type const target_capacity ) noexcept { return shell().try_expand( reinterpret_cast<typename shell_t::pointer>( ptr ), shell_byte_count( target_capacity ) ); }
 
 public:
-    constexpr heap_storage() noexcept : allocator_type{}, p_array_{ nullptr }, size_{ 0 }, capacity_{ 0 } {}
+    constexpr heap_storage() noexcept : shell_t{}, p_array_{ nullptr }, size_{ 0 }, capacity_{ 0 } {}
 
     // Construct with an explicit allocator (for stateful allocators).
-    constexpr explicit heap_storage( allocator_type alloc_init ) noexcept
-        : allocator_type{ std::move( alloc_init ) }, p_array_{ nullptr }, size_{ 0 }, capacity_{ 0 } {}
+    constexpr explicit heap_storage( allocator_type alloc_init ) noexcept requires ( !std::is_void_v<Allocator> )
+        : shell_t{ std::move( alloc_init ) }, p_array_{ nullptr }, size_{ 0 }, capacity_{ 0 } {}
 
     constexpr ~heap_storage() noexcept
     {
@@ -115,7 +164,7 @@ public:
     heap_storage & operator=( heap_storage const & ) = delete;
 
     constexpr heap_storage( heap_storage && other ) noexcept
-        : allocator_type{ static_cast<allocator_type &&>( other ) }
+        : shell_t{ static_cast<shell_t &&>( other ) }
         , p_array_ { other.p_array_  }
         , size_    { other.size_     }
         , capacity_{ other.capacity_ }
@@ -125,7 +174,7 @@ public:
     {
         if ( p_array_ )
             storage_free();
-        static_cast<allocator_type &>( *this ) = static_cast<allocator_type &&>( other );
+        static_cast<shell_t &>( *this ) = static_cast<shell_t &&>( other );
         p_array_  = other.p_array_;
         size_     = other.size_;
         if constexpr ( options.cache_capacity )
@@ -144,7 +193,10 @@ public:
         }
         else
         {
-            return empty() ? 0 : alloc().size( p_array_ );
+            if constexpr ( std::is_void_v<Allocator> )
+                return empty() ? size_type{} : shell_capacity( p_array_ );
+            else
+                return empty() ? 0 : alloc().size( p_array_ );
         }
     }
 
@@ -161,17 +213,45 @@ public:
         }
     }
 
-    constexpr allocator_type get_allocator() const noexcept { return alloc(); }
+    constexpr allocator_type get_allocator() const noexcept
+    {
+        if constexpr ( std::is_void_v<Allocator> )
+            return allocator_type{};
+        else
+            return alloc();
+    }
 
     auto release() noexcept { auto d{ p_array_ }; mark_freed(); return d; }
 
     void swap( heap_storage & other ) noexcept
     {
         using std::swap;
-        swap( static_cast<allocator_type &>( *this ), static_cast<allocator_type &>( other ) );
+        swap( static_cast<shell_t &>( *this ), static_cast<shell_t &>( other ) );
         swap( p_array_ , other.p_array_  );
         swap( size_    , other.size_     );
         swap( capacity_, other.capacity_ );
+    }
+
+    // Raw element-count allocate/deallocate for external owners (backing stores, etc.).
+    // Void-Allocator path uses the byte shell; custom-Allocator path uses element semantics.
+    [[nodiscard]] static pointer allocate_external( size_type const element_count )
+    {
+        if constexpr ( std::is_void_v<Allocator> )
+            return reinterpret_cast<pointer>(
+                detail::heap_shell_allocator<sz_t>::template allocate<alignment>(
+                    static_cast<typename detail::heap_shell_allocator<sz_t>::size_type>( byte_count( element_count ) ) ) );
+        else
+            return allocator_type::template allocate<alignment>( element_count );
+    }
+
+    static void deallocate_external( pointer const ptr, size_type const element_count ) noexcept
+    {
+        if constexpr ( std::is_void_v<Allocator> )
+            detail::heap_shell_allocator<sz_t>::template deallocate<alignment>(
+                reinterpret_cast<typename detail::heap_shell_allocator<sz_t>::pointer>( ptr ),
+                static_cast<typename detail::heap_shell_allocator<sz_t>::size_type>( byte_count( element_count ) ) );
+        else
+            allocator_type::template deallocate<alignment>( ptr, element_count );
     }
 
     // --- storage_* interface for vector<> ---
@@ -180,7 +260,10 @@ public:
     {
         if ( initial_size )
         {
-            p_array_ = alloc().template allocate<alignment>( initial_size );
+            if constexpr ( std::is_void_v<Allocator> )
+                p_array_ = shell_allocate( initial_size );
+            else
+                p_array_ = alloc().template allocate<alignment>( initial_size );
             size_    = initial_size;
             update_capacity( initial_size );
         }
@@ -219,11 +302,19 @@ public:
             // skip realloc, just update metadata. The allocator may release
             // trailing pages but the pointer is stable.
             if constexpr ( has_try_shrink_in_place<al> )
-                BOOST_VERIFY( alloc().try_shrink_in_place( p_array_, size_, target_size ) );
+            {
+                if constexpr ( std::is_void_v<Allocator> )
+                    BOOST_VERIFY( shell().try_shrink_in_place( reinterpret_cast<typename shell_t::pointer>( p_array_ ), shell_byte_count( size_ ), shell_byte_count( target_size ) ) );
+                else
+                    BOOST_VERIFY( alloc().try_shrink_in_place( p_array_, size_, target_size ) );
+            }
         }
         else
         {
-            p_array_ = alloc().template shrink_to<alignment>( p_array_, size_, target_size );
+            if constexpr ( std::is_void_v<Allocator> )
+                p_array_ = shell_shrink_to( p_array_, size_, target_size );
+            else
+                p_array_ = alloc().template shrink_to<alignment>( p_array_, size_, target_size );
         }
         BOOST_ASSUME( p_array_ || !target_size );
         BOOST_ASSUME( is_aligned( p_array_, alignment ) );
@@ -243,25 +334,40 @@ public:
     bool storage_try_expand_capacity( size_type const target_capacity ) noexcept
     requires( options.cache_capacity && ( !al::in_place_ops_require_default_alignment || alignment <= detail::guaranteed_alignment ) )
     {
-        namespace bc = boost::container;
-        auto recv_size{ target_capacity };
-        auto reuse    { p_array_ };
-        auto const result{ alloc().allocation_command(
-            bc::expand_fwd | bc::nothrow_allocation,
-            target_capacity, recv_size, reuse
-        ) };
-        if ( result )
+        if constexpr ( std::is_void_v<Allocator> )
         {
-            update_capacity( recv_size );
-            return true;
+            if ( shell_try_expand( p_array_, target_capacity ) )
+            {
+                update_capacity( target_capacity );
+                return true;
+            }
+            return false;
         }
-        return false;
+        else
+        {
+            namespace bc = boost::container;
+            auto recv_size{ target_capacity };
+            auto reuse    { p_array_ };
+            auto const result{ alloc().allocation_command(
+                bc::expand_fwd | bc::nothrow_allocation,
+                target_capacity, recv_size, reuse
+            ) };
+            if ( result )
+            {
+                update_capacity( recv_size );
+                return true;
+            }
+            return false;
+        }
     }
 #endif
 
     void storage_free() noexcept
     {
-        alloc().template deallocate<alignment>( data(), options.cache_capacity ? capacity() : 0 );
+        if constexpr ( std::is_void_v<Allocator> )
+            shell_deallocate( data(), options.cache_capacity ? capacity() : size_type{} );
+        else
+            alloc().template deallocate<alignment>( data(), options.cache_capacity ? capacity() : 0 );
         mark_freed();
     }
 
@@ -275,7 +381,10 @@ private:
         if ( !p_array_ ) [[ unlikely ]]
         {
             BOOST_ASSUME( !size_ );
-            p_array_ = alloc().template allocate<alignment>( new_capacity );
+            if constexpr ( std::is_void_v<Allocator> )
+                p_array_ = shell_allocate( new_capacity );
+            else
+                p_array_ = alloc().template allocate<alignment>( new_capacity );
             update_capacity( new_capacity );
             return;
         }
@@ -289,13 +398,21 @@ private:
         if constexpr ( is_trivially_moveable<T> )
         {
             // Safe to use realloc (bitwise relocation)
-            p_array_ = alloc().template grow_to<alignment>( p_array_, cached_current_capacity, new_capacity );
+            if constexpr ( std::is_void_v<Allocator> )
+                p_array_ = shell_grow_to( p_array_, cached_current_capacity, new_capacity );
+            else
+                p_array_ = alloc().template grow_to<alignment>( p_array_, cached_current_capacity, new_capacity );
         }
         else
         {
             if constexpr ( can_try_expand )
             {
-                if ( !alloc().try_expand( p_array_, new_capacity ) )
+                bool expanded{ false };
+                if constexpr ( std::is_void_v<Allocator> )
+                    expanded = shell_try_expand( p_array_, new_capacity );
+                else
+                    expanded = alloc().try_expand( p_array_, new_capacity );
+                if ( !expanded )
                     relocate_to( new_capacity, cached_current_capacity );
             }
             else
@@ -312,18 +429,28 @@ private:
     // destination elements on exception; unique_ptr frees the new allocation.
     void relocate_to( size_type const new_cap, size_type const old_cap )
     {
+        value_type * new_ptr;
+        if constexpr ( std::is_void_v<Allocator> )
+            new_ptr = shell_allocate( new_cap );
+        else
+            new_ptr = alloc().template allocate<alignment>( new_cap );
+
         auto const free_new{ [ this, new_cap ]( value_type * p ) noexcept {
-            alloc().template deallocate<alignment>( p, new_cap );
+            if constexpr ( std::is_void_v<Allocator> )
+                shell_deallocate( p, new_cap );
+            else
+                alloc().template deallocate<alignment>( p, new_cap );
         } };
-        std::unique_ptr<value_type, decltype( free_new )> guard{
-            alloc().template allocate<alignment>( new_cap ), free_new
-        };
+        std::unique_ptr<value_type, decltype( free_new )> guard{ new_ptr, free_new };
         std::uninitialized_move_n( p_array_, size_, guard.get() );
-        auto * const new_ptr{ guard.release() }; // move succeeded, take ownership
+        auto * const relocated{ guard.release() }; // move succeeded, take ownership
         if constexpr ( !trivially_destructible_after_move_assignment<T> )
             std::destroy_n( p_array_, size_ );
-        alloc().template deallocate<alignment>( p_array_, options.cache_capacity ? old_cap : size_type{} );
-        p_array_ = new_ptr;
+        if constexpr ( std::is_void_v<Allocator> )
+            shell_deallocate( p_array_, options.cache_capacity ? old_cap : size_type{} );
+        else
+            alloc().template deallocate<alignment>( p_array_, options.cache_capacity ? old_cap : size_type{} );
+        p_array_ = relocated;
     }
 
     void update_capacity( [[ maybe_unused ]] size_type const requested_capacity ) noexcept
@@ -331,10 +458,16 @@ private:
         BOOST_ASSUME( p_array_ || !requested_capacity );
         if constexpr ( options.cache_capacity ) {
 #       if defined( _MSC_VER )
-            BOOST_ASSERT( !requested_capacity || ( alloc().size( p_array_ ) >= requested_capacity ) );
+            if constexpr ( std::is_void_v<Allocator> )
+                BOOST_ASSERT( !requested_capacity || ( shell_capacity( p_array_ ) >= requested_capacity ) );
+            else
+                BOOST_ASSERT( !requested_capacity || ( alloc().size( p_array_ ) >= requested_capacity ) );
             capacity_ = requested_capacity;
 #       else
-            capacity_ = alloc().size( p_array_ );
+            if constexpr ( std::is_void_v<Allocator> )
+                capacity_ = shell_capacity( p_array_ );
+            else
+                capacity_ = alloc().size( p_array_ );
             BOOST_ASSUME( capacity_ >= requested_capacity );
 #       endif
         }
@@ -359,11 +492,12 @@ private:
     std::conditional_t<options.cache_capacity, sz_t, decltype( std::ignore )> capacity_;
 }; // class heap_storage
 
-// heap_storage is trivially moveable when the allocator is trivially copyable
-// (all stateless allocators + allocators holding raw pointers).
+// heap_storage is trivially moveable when the EBO shell allocator is trivially copyable.
 template <typename T, typename sz_t, typename Allocator, heap_options options>
 bool constexpr is_trivially_moveable<heap_storage<T, sz_t, Allocator, options>>{
-    std::is_trivially_copyable_v<typename heap_storage<T, sz_t, Allocator, options>::allocator_type>
+    std::is_trivially_copyable_v<
+        std::conditional_t<std::is_void_v<Allocator>, detail::heap_shell_allocator<sz_t>, Allocator>
+    >
 };
 
 //------------------------------------------------------------------------------

--- a/include/psi/vm/containers/vector.hpp
+++ b/include/psi/vm/containers/vector.hpp
@@ -28,6 +28,7 @@
 
 #include <psi/vm/align.hpp>
 #include <psi/vm/containers/abi.hpp>
+#include <psi/vm/containers/complete.hpp>
 #include <psi/vm/containers/growth_policy.hpp>
 #include <psi/vm/containers/is_trivially_moveable.hpp>
 #include <psi/vm/containers/trivially_destructible_after_move.hpp>
@@ -64,6 +65,33 @@ namespace detail
 {
     // throw_out_of_range declared in abi.hpp, defined in vm_vector.cpp
 
+    template <bool support_incomplete_types, typename value_type>
+    struct vector_value_types
+    {
+        // Default path: pass_in_reg (works for complete T).
+        using param_const_ref = pass_in_reg<value_type>;
+#if defined( _LIBCPP_ABI_BOUNDED_ITERATORS_IN_VECTOR )
+        using       iterator         = std::__bounded_iter<value_type *>;
+        using const_iterator         = std::basic_const_iterator<iterator>;
+#elif defined( _ITERATOR_DEBUG_LEVEL ) && _ITERATOR_DEBUG_LEVEL
+        using       iterator         = std::_Span_iterator<value_type>;
+        using const_iterator         = std::basic_const_iterator<iterator>;
+#else
+        using       iterator         = value_type *;
+        using const_iterator         = value_type const *;
+#endif
+    };
+
+    template <typename value_type>
+    struct vector_value_types<true, value_type>
+    {
+        // Incomplete / recursive strong-typedef value_type: avoid complete<T>
+        // and checked iterators at class scope.
+        using param_const_ref        = value_type const &;
+        using       iterator         = value_type *;
+        using const_iterator         = value_type const *;
+    };
+
     template <typename T>
     constexpr T * mutable_iter( T const * const ptr ) noexcept { return const_cast<T *>( ptr ); }
 
@@ -72,7 +100,7 @@ namespace detail
 #if defined( _LIBCPP_ABI_BOUNDED_ITERATORS_IN_VECTOR )
     template <typename T>
     auto mutable_iter( std::__bounded_iter<T const *> const iter ) noexcept { return reinterpret_cast<std::__bounded_iter<T *> const &>( iter ); }
-#elif _ITERATOR_DEBUG_LEVEL
+#elif defined( _ITERATOR_DEBUG_LEVEL ) && _ITERATOR_DEBUG_LEVEL
     template <typename T>
     auto mutable_iter( std::_Span_iterator<T const> const iter ) noexcept { return reinterpret_cast<std::_Span_iterator<T> const &>( iter ); }
 #endif
@@ -204,12 +232,13 @@ concept psi_vm_vector = requires { typename std::remove_cvref_t<T>::psi_vm_vecto
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename Storage, geometric_growth Growth = geometric_growth{}>
+template <typename Storage, geometric_growth Growth = geometric_growth{}, bool support_incomplete_types = false>
 class [[ nodiscard, clang::trivial_abi ]] vector
     :
     public Storage
 {
     using storage_t = Storage;
+    using value_types = detail::vector_value_types<support_incomplete_types, typename storage_t::value_type>;
 
 public:
     using psi_vm_vector_tag      = void; // tag for constraining free comparison operators
@@ -219,23 +248,10 @@ public:
     using const_pointer          = value_type const *;
     using       reference        = value_type       &;
     using const_reference        = value_type const &;
-#if 0 // fails for incomplete T
-    using param_const_ref        = std::conditional_t<can_be_passed_in_reg<value_type>, value_type const, pass_in_reg<value_type>>;
-#else
-    using param_const_ref        = pass_in_reg<value_type>;
-#endif
+    using param_const_ref        = typename value_types::param_const_ref;
     using difference_type        = std::make_signed_t<size_type>;
-#if defined( _LIBCPP_ABI_BOUNDED_ITERATORS_IN_VECTOR )
-    using       iterator         = std::__bounded_iter<pointer>;
-    using const_iterator         = std::basic_const_iterator<iterator>; // __bounded_iter<T> is not convertible to __bounded_iter<T const> so we have to use the std wrapper
-#elif _ITERATOR_DEBUG_LEVEL
-    // checked_array_iterator is deprecated so use the span iterator wrapper
-    using       iterator         = std::_Span_iterator<value_type>;
-    using const_iterator         = std::basic_const_iterator<iterator>; // same as for __bounded_iter
-#else
-    using       iterator         =       pointer;
-    using const_iterator         = const_pointer;
-#endif
+    using       iterator         = typename value_types::iterator;
+    using const_iterator         = typename value_types::const_iterator;
     using       reverse_iterator = std::reverse_iterator<      iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -244,13 +260,17 @@ private:
     constexpr auto   end_ptr( this auto & self ) noexcept { return self.data() + self.size(); }
     constexpr iterator make_iterator( value_type * const ptr ) noexcept
     {
-        return
+        if constexpr ( support_incomplete_types )
+            return ptr;
 #   if defined( _LIBCPP_ABI_BOUNDED_ITERATORS_IN_VECTOR )
-            std::__make_bounded_iter( ptr, begin_ptr(), end_ptr() );
-#   elif _ITERATOR_DEBUG_LEVEL
-            std::_Span_iterator{ ptr, begin_ptr(), end_ptr() };
+        else if constexpr ( true )
+            return std::__make_bounded_iter( ptr, begin_ptr(), end_ptr() );
+#   elif defined( _ITERATOR_DEBUG_LEVEL ) && _ITERATOR_DEBUG_LEVEL
+        else if constexpr ( true )
+            return std::_Span_iterator{ ptr, begin_ptr(), end_ptr() };
 #   else
-            ptr;
+        else
+            return ptr;
 #   endif
     }
     constexpr iterator make_iterator( size_type const offset ) noexcept
@@ -1229,9 +1249,9 @@ public:
         : storage_t{ std::move( init ) }
     {}
 
-    // --- destructor ---
     constexpr ~vector() noexcept
     {
+        static_assert( complete<value_type>, "vector destructor requires a complete value_type" );
         std::destroy_n( this->data(), this->size() );
     }
 
@@ -1249,6 +1269,8 @@ public:
     //     element-level copy semantics live here at the vector level.
     constexpr vector( vector const & other ) requires ( !std::is_copy_constructible_v<storage_t> )
     {
+        if constexpr ( !support_incomplete_types )
+            static_assert( complete<value_type>, "vector copy requires a complete value_type" );
         // Optimization for small trivially-copyable fixed-capacity vectors:
         // memcpy the entire object (size + inline array) with a handful of
         // register-width instructions instead of a dynamic memcpy call.
@@ -1287,7 +1309,7 @@ public:
     {
         if ( this != &other )
         {
-            // Destroy current elements
+            static_assert( complete<value_type>, "vector move assignment requires a complete value_type" );
             std::destroy_n( this->data(), this->size() );
             // Move storage from other
             static_cast<storage_t &>( *this ) = std::move( static_cast<storage_t &>( other ) );
@@ -1326,9 +1348,9 @@ PSI_WARNING_DISABLE_POP()
 
 // is_trivially_moveable: heap_storage is always trivially moveable (just pointer+sizes);
 // fixed_storage delegates to element type.
-template <typename Storage, geometric_growth Growth>
+template <typename Storage, geometric_growth Growth, bool support_incomplete_types>
 requires( is_trivially_moveable<Storage> )
-bool constexpr is_trivially_moveable<vector<Storage, Growth>>{ true };
+bool constexpr is_trivially_moveable<vector<Storage, Growth, support_incomplete_types>>{ true };
 
 //------------------------------------------------------------------------------
 

--- a/test/vector_storage.cpp
+++ b/test/vector_storage.cpp
@@ -240,10 +240,58 @@ struct incomplete_type; // forward declaration only -- never completed in this T
 // an incomplete type. The key: sizeof(T) is only needed in method bodies
 // (deferred instantiation), not in the class definition.
 static_assert( sizeof( heap_storage<incomplete_type> ) > 0 );
-static_assert( sizeof( vector<heap_storage<incomplete_type>> ) > 0 );
+static_assert( sizeof( vector<heap_storage<incomplete_type>, geometric_growth{}, true> ) > 0 );
 
-// heap_vector<T> = vector<heap_storage<T>> so it should also work
-static_assert( sizeof( heap_vector<incomplete_type> ) > 0 );
+// heap_vector<T, ..., support_incomplete_types=true> for recursive / incomplete T
+static_assert( sizeof( heap_vector<incomplete_type, std::size_t, {}, {}, true> ) > 0 );
+
+// Recursive strong-typedef: struct Body : vector<Rec> while Rec is still incomplete.
+// std::vector<Rec> tolerates this; heap_vector<Rec, ..., true> must too.
+struct recursive_record;
+using recursive_vec = heap_vector<recursive_record, std::size_t, {}, {}, true>;
+struct recursive_body : recursive_vec {
+    using recursive_vec::recursive_vec;
+};
+static_assert( sizeof( recursive_body ) > 0 );
+
+// Recursive variant + vector body.
+struct variant_record;
+using variant_body_vec = heap_vector<variant_record, std::size_t, {}, {}, true>;
+struct variant_body : variant_body_vec {
+    using variant_body_vec::variant_body_vec;
+};
+using variant_record_variant = std::variant<int, variant_body>;
+struct variant_record : variant_record_variant {
+    using variant_record_variant::variant_record_variant;
+};
+static_assert( sizeof( variant_record ) > 0 );
+
+// Nested template + external member holding a conjoined vector body (filter_ast-style).
+// Node stays forward-declared only (heap_vector element type); holder proves the
+// external-member pattern compiles. variant_record above covers variant + body.
+namespace recursive_typedef_compile_tests {
+
+template <typename... AltTypes> struct Node;
+
+template <typename... AltTypes>
+struct node_expr {
+    using node = Node<AltTypes...>;
+    using nodes = heap_vector<node, std::uint32_t, {}, {}, true>;
+    struct [[ clang::trivial_abi ]] conjoined_nodes : nodes {
+        static constexpr bool is_trivially_moveable{ false };
+        using nodes::nodes;
+    };
+};
+
+struct leaf { int x; };
+
+struct holder {
+    typename node_expr<leaf>::conjoined_nodes body;
+};
+
+static_assert( sizeof( holder ) > 0 );
+
+} // namespace recursive_typedef_compile_tests
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

- Add `complete<T>` and guard trait queries for incomplete types.
- Rework `heap_storage` with a T-independent byte shell allocator so recursive `struct Body : heap_vector<Rec>` instantiates on MSVC without pulling variant SMF traits at class scope.
- Add `vector<Storage, Growth, support_incomplete_types=false>`: when `true`, raw-pointer iterators and deferred element destroy (vector dtor + `storage_free` split) for recursive strong typedefs / filter AST patterns.
- Tests: incomplete/recursive/variant-shaped compile checks in `vector_storage.cpp`.

## Commits (3)

1. **feat(vector)** — core incomplete-type support + tests
2. **test(mapped_view)** — `RAMA_TEST_NO_DURABLE_FLUSH=1` for faster CI/jest
3. **ci(clang-cl)** — gtest char8_t `-Werror` suppression

## Test plan

- [x] CI green on Windows + Linux + macOS
- [x] `vector_storage` tests pass