### PR TITLE
test(mapped_view): skip durable flush when RAMA_TEST_NO_DURABLE_FLUSH=1

### DIFF
--- a/src/mapped_view/mapped_view.posix.cpp
+++ b/src/mapped_view/mapped_view.posix.cpp
@@ -17,6 +17,8 @@
 #include <psi/vm/mapped_view/ops.hpp>
 
 #include <boost/assert.hpp>
+
+#include <cstdlib>
 //------------------------------------------------------------------------------
 namespace psi::vm
 {
@@ -164,6 +166,12 @@ void flush_async( mapped_span const range ) noexcept
 
 void flush_blocking( mapped_span const range ) noexcept
 {
+    // RAMA_TEST_NO_DURABLE_FLUSH=1 skips MS_SYNC for test/CI runs where crash-
+    // recovery durability is not required (model harness no-commit mode).
+    if ( char const * const v{ std::getenv( "RAMA_TEST_NO_DURABLE_FLUSH" ) }; v && v[ 0 ] && v[ 0 ] != '0' ) {
+        call_msync( range, MS_ASYNC );
+        return;
+    }
     // MS_INVALIDATE should not be necessary on OSes with coherent/unified
     // caches? Even if it is necessary it is not clear that the user would want
     // it in all use cases (certainly not for mappings to which only a single

--- a/src/mapped_view/mapped_view.win32.cpp
+++ b/src/mapped_view/mapped_view.win32.cpp
@@ -24,6 +24,8 @@
 
 #include <boost/assert.hpp>
 
+#include <cstdlib>
+
 #ifndef NDEBUG
 #include <cstdio> // for fputs
 #endif
@@ -216,6 +218,11 @@ void flush_async( mapped_span const range ) noexcept
 void flush_blocking( mapped_span const range, file_handle::const_reference const source_file ) noexcept
 {
     flush_async( range );
+    // RAMA_TEST_NO_DURABLE_FLUSH=1 skips FlushFileBuffers for test/CI runs where
+    // crash-recovery durability is not required (model harness no-commit mode).
+    if ( char const * const v{ std::getenv( "RAMA_TEST_NO_DURABLE_FLUSH" ) }; v && v[ 0 ] && v[ 0 ] != '0' ) {
+        return;
+    }
     // https://devblogs.microsoft.com/oldnewthing/20100909-00/?p=12913 Flushing your performance down the drain, that is
     BOOST_VERIFY( ::FlushFileBuffers( source_file.value ) );
 }


### PR DESCRIPTION
## Summary

Skip blocking `MS_SYNC` / `FlushFileBuffers` when `RAMA_TEST_NO_DURABLE_FLUSH=1` is set. CI and local jest runs do not need crash-recovery durability on every commit.

## Rama companion

Pinned from `farseerdev/rama` PR #601 (`ci/rama-build-speedups`).