### PR TITLE
perf(vector): grow_by_amortized for bulk append; reserve/grow_by stay exact

### DIFF
--- a/include/psi/vm/containers/vector.hpp
+++ b/include/psi/vm/containers/vector.hpp
@@ -1204,6 +1204,25 @@ public:
         return grow_to( this->size() + delta, init_policy );
     }
 
+    // Amortized-O(1) bulk append. Unlike grow_by/grow_to (exact-fit), this sizes
+    // capacity with the container's geometric Growth policy — the same headroom
+    // emplace_back gets — so callers that append in a loop and cannot pre-reserve
+    // (e.g. a variable-length column whose element sizes are only known one cell at
+    // a time) extend the backing store O(log n) times instead of once per call.
+    // reserve()/grow_by() stay exact so one-shot sizing keeps file-backed data
+    // compact; the geometric target is computed here and reserved explicitly,
+    // leaving reserve()/expand_capacity() semantics untouched.
+    value_type * grow_by_amortized( size_type const delta, auto const init_policy )
+    {
+        auto const target{ static_cast<size_type>( this->size() + delta ) };
+        if constexpr ( static_cast<bool>( Growth ) ) {
+            if ( target > this->capacity() ) {
+                this->reserve( Growth( target, this->capacity() ) );
+            }
+        }
+        return grow_to( target, init_policy ); // capacity already sized -> no per-call extend
+    }
+
     void shrink_to( size_type const target_size ) noexcept
     {
         BOOST_ASSUME( target_size <= this->size() );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,11 @@ CPMAddPackage( "gh:google/googletest@1.15.2" )
 include( GoogleTest )
 if ( MSVC )
     target_compile_options( gtest PRIVATE /fp:precise )
+    if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" ) # clang-cl
+        # GTest's value printers convert char8_t -> char32_t, which clang-cl flags
+        # as -Wcharacter-conversion; with the toolchain's -Werror that fails gtest.
+        target_compile_options( gtest PRIVATE -Wno-character-conversion )
+    endif()
 else()
     target_compile_options( gtest PRIVATE -fno-fast-math )
 endif()

--- a/test/b+tree.cpp
+++ b/test/b+tree.cpp
@@ -152,7 +152,14 @@ TEST( bp_tree, playground )
         EXPECT_FALSE( bpt.insert( 42 ).second );
         EXPECT_EQ   ( *bpt.insert( 42 ).first, 42 );
         EXPECT_TRUE( std::ranges::equal(                      bpt.random_access()  ,                      sorted_numbers   ) );
+#   if defined( _MSC_VER ) && defined( __clang__ ) // clang-cl
+        // clang-cl + MSVC STL <concepts> recurses satisfying basic_const_iterator's
+        // comparison constraints under reverse_view here; compare a materialized copy.
+        auto const bpt_ra{ std::ranges::to<std::vector>( bpt.random_access() ) };
+        EXPECT_TRUE( std::ranges::equal( std::views::reverse( bpt_ra ), std::views::reverse( sorted_numbers ) ) );
+#   else
         EXPECT_TRUE( std::ranges::equal( std::views::reverse( bpt.random_access() ), std::views::reverse( sorted_numbers ) ) );
+#   endif
 
         EXPECT_TRUE( bpt.erase( 42 ) );
         auto const hint42{ bpt.lower_bound( 42 ) };


### PR DESCRIPTION
## Problem

`grow_by` / `grow_to` / `resize` are exact-fit by design — they size the backing
store to precisely the requested size, because a persisted, file-backed store must
not silently over-allocate on explicit sizing. But there is no amortized append
primitive for a *run* of elements: `emplace_back` amortizes one element at a time
(via the container's geometric `Growth`), while `grow_by(n)` is exact.

So a caller that appends in a loop and cannot pre-reserve — e.g. a variable-length
column whose element sizes are known only one cell at a time — re-extended the
file-backed section (`ftruncate` on POSIX, `NtExtendSection` on Windows) on **every
call**: `O(n)` `set_size` syscalls, hundreds of thousands for a multi-GB build.

## Fix

Add `vector::grow_by_amortized(delta, init_policy)`: it sizes capacity with the
container's geometric `Growth` policy (the same headroom `emplace_back` gets) —
computing the geometric target itself and `reserve()`-ing it explicitly — then
delegates to the exact `grow_to()` for the size + init. The section is therefore
extended `O(log n)` times instead of once per element.

Crucially this keeps **`reserve()` / `expand_capacity()` exact-fit**: the growth
policy lives at the call site, not in `reserve`. (An earlier revision of this PR
put geometric growth *inside* `expand_capacity`; that overloaded `reserve`'s
contract for every caller and is dropped per review.) The mapped **view** is also
kept exact — only the backing-section capacity runs ahead — so no extra address
space is committed or page-faulted, and peak RSS / mapped size are unchanged.
`shrink` / `shrink_to_fit` reclaim the geometric slack.

## Impact

A downstream Rama bulk import that builds a variable-length column cell-by-cell,
exact `grow_by` → `grow_by_amortized` (Windows, Release, usr+krn CPU, median of
interleaved runs):

| Import | before | after | Δ |
|--------|-------:|------:|--:|
| 325 MB | 7796 ms | 6281 ms | **−19%** |
| 3.4 GB | 30452 ms | 26999 ms | **−11%** |

The view is kept exact, so peak RSS and mapped size are unchanged (dwVmSize
+1 MB). Section-extend syscalls drop `O(n)` → `O(log n)`; whether that becomes a
wall-time win depends on the platform's extend cost — Windows `NtExtendSection`
commits pages (clear win), Linux/ext4 `ftruncate` is a near-free sparse metadata
op (robustness win, cpuTime unchanged).

## Also — clang-cl test build fix

Two pre-existing clang-cl `-Werror` failures in the **test** build, both MSVC-STL
interactions unrelated to library code:

- GTest's value printers convert `char8_t` → `char32_t` (`-Wcharacter-conversion`)
  — suppressed on the `gtest` target for clang-cl.
- `b+tree.cpp`: `std::ranges::equal` over a `reverse_view` of a const random-access
  range makes MSVC STL `<concepts>` recurse satisfying `basic_const_iterator`'s
  comparison constraints under clang-cl — compare a materialized copy there.

Full CI matrix now green (GCC / Clang / clang-cl / MSVC / Apple-Clang, Debug + Release).
