### PR TITLE
fix(fixed_storage): include cstring for std::memcpy under NO_PCH builds

### DIFF
--- a/include/psi/vm/containers/storage/fixed.hpp
+++ b/include/psi/vm/containers/storage/fixed.hpp
@@ -33,6 +33,7 @@
 #include <boost/config_ex.hpp>
 #include <boost/integer.hpp>
 
+#include <cstring>
 #include <memory>
 #include <utility>
 //------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add \#include <cstring>\ to \ixed_storage\ — move constructor uses \std::memcpy\ but the header did not include it.
- Without PCH (rama sanitizer CI uses \RAMA_NO_PCH=ON\), clang no longer gets \<cstring>\ transitively and the build fails.

## Test plan
- [x] rama WSL ASan/TSan builds with \RAMA_NO_PCH=ON\

Made with [Cursor](https://cursor.com)