### PR TITLE
fix: MSVC debug-iterator relocation safety + incomplete recursive value_types

### DIFF
--- a/include/psi/vm/containers/heap_vector.hpp
+++ b/include/psi/vm/containers/heap_vector.hpp
@@ -31,7 +31,11 @@ namespace psi::vm
 // The 'void' Allocator default auto-computes to crt_allocator with correct alignment.
 // Growth policy lives at the vector<> level, not inside storage.
 template <typename T, typename sz_t = std::size_t, heap_options options = {}, geometric_growth growth = {}, bool support_incomplete_types = false>
-using heap_vector = vector<heap_storage<T, sz_t, void, options>, growth, support_incomplete_types>;
+using heap_vector = vector<
+    // propagate support_incomplete_types into the storage so its class-scope
+    // alignment constant defers alignof(T) (avoids a recursive completeness probe)
+    heap_storage<T, sz_t, void, heap_options{ options.alignment, options.cache_capacity, options.defer_alignment || support_incomplete_types }>,
+    growth, support_incomplete_types>;
 
 // Generic erase_if / erase are provided in vector.hpp for all psi_vm_vector types.
 

--- a/include/psi/vm/containers/is_trivially_moveable.hpp
+++ b/include/psi/vm/containers/is_trivially_moveable.hpp
@@ -104,6 +104,24 @@ namespace psi::vm
 // https://github.com/llvm/llvm-project/issues/69394 is_trivially_relocatable isn't correct under Windows
 // https://github.com/llvm/llvm-project/issues/86354 is_trivially_relocatable isn't correct under Apple Clang
 
+// Microsoft STL with debug iterators (_ITERATOR_DEBUG_LEVEL != 0) gives every
+// container an extra heap-allocated _Container_proxy whose _Mycont back-pointer
+// is maintained by the move constructor but NOT by a raw memmove: such objects
+// are therefore NOT bitwise relocatable. Additionally, Clang's relocatability
+// builtins are unreliable under the Windows ABI (llvm#69394) and would wrongly
+// green-light a memmove of these proxy-bearing types (directly, when derived
+// from a container, or when a [[clang::trivial_abi]] attribute is ABI-ignored
+// yet still flips __is_trivially_relocatable). Mirror the _LIBCPP_DEBUG handling
+// below: in such builds ignore those builtins and drop the container
+// specializations, so classification falls back to the honest core triviality
+// traits (which are false for any proxy-bearing type). Release (IDL==0) is
+// unaffected — the fast bitwise-relocation path is retained.
+#if defined( _MSVC_STL_VERSION ) && ( _ITERATOR_DEBUG_LEVEL != 0 )
+#   define PSI_VM_STL_DEBUG_ITERATORS 1
+#else
+#   define PSI_VM_STL_DEBUG_ITERATORS 0
+#endif
+
 PSI_WARNING_DISABLE_PUSH()
 PSI_WARNING_CLANG_DISABLE( -Wdeprecated-builtins )
 // allowed/expected to be user-specialized for custom types.
@@ -116,6 +134,7 @@ PSI_WARNING_CLANG_DISABLE( -Wdeprecated-builtins )
 template <typename T>
 bool constexpr is_trivially_moveable
 {
+#if !PSI_VM_STL_DEBUG_ITERATORS // see note above: Clang relocatability builtins are unreliable under Windows debug STL
 #if defined( __cpp_trivial_relocatability ) || __has_builtin( __builtin_is_cpp_trivially_relocatable )
     __builtin_is_cpp_trivially_relocatable( T ) ||
 #endif
@@ -125,6 +144,7 @@ bool constexpr is_trivially_moveable
 #if defined( __cpp_lib_trivially_relocatable ) // P1144 or P2786 library support
     std::is_trivially_relocatable<T> ||
 #endif
+#endif // !PSI_VM_STL_DEBUG_ITERATORS
     std::is_trivially_copyable_v<T> || // implies trivial destructibility https://eel.is/c++draft/class.prop#1
     std::is_trivially_move_assignable_v<T> ||
     std::is_trivially_move_constructible_v<T> // beyond P2786 optimistic heuristic https://github.com/psiha/vm/pull/34#discussion_r1914536293
@@ -140,10 +160,15 @@ bool constexpr is_trivially_moveable<std::pair<T1, T2>>{ is_trivially_moveable<T
 template <typename T, std::size_t size>
 bool constexpr is_trivially_moveable<std::array<T, size>>{ is_trivially_moveable<T> };
 #if !defined( _LIBCPP_DEBUG )
-template <typename T            , typename A> bool constexpr is_trivially_moveable<std::vector      <T, A   >>{ is_trivially_moveable<A> };
 template <typename T            , typename D> bool constexpr is_trivially_moveable<std::unique_ptr  <T, D   >>{ is_trivially_moveable<D> };
 #endif
-#if !defined( _LIBCPP_DEBUG ) && !defined( __GLIBCXX__ )
+// std::vector / std::basic_string carry a _Container_proxy back-pointer under
+// MSVC debug iterators — suppress the allocator-only "trivially moveable" claim
+// there (as for _LIBCPP_DEBUG), leaving them to the honest fallback traits.
+#if !defined( _LIBCPP_DEBUG ) && !PSI_VM_STL_DEBUG_ITERATORS
+template <typename T            , typename A> bool constexpr is_trivially_moveable<std::vector      <T, A   >>{ is_trivially_moveable<A> };
+#endif
+#if !defined( _LIBCPP_DEBUG ) && !defined( __GLIBCXX__ ) && !PSI_VM_STL_DEBUG_ITERATORS
 template <typename E, typename T, typename A> bool constexpr is_trivially_moveable<std::basic_string<E, T, A>>{ is_trivially_moveable<A> };
 #endif
 #if defined( __GLIBCXX__ )

--- a/include/psi/vm/containers/storage/heap.hpp
+++ b/include/psi/vm/containers/storage/heap.hpp
@@ -47,6 +47,13 @@ struct heap_options
 {
     std::uint8_t alignment     { 0    }; // 0 -> default
     bool         cache_capacity{ true }; // if your crt_alloc_size is slow (MSVC)
+    // When the value_type is an incomplete/recursive strong-typedef (the vector's
+    // support_incomplete_types mode), the class-scope alignment constant must not
+    // probe complete<T>/alignof(T): that probe is an ODR hazard that can flip to
+    // `true` on a late instantiation and pull the (still-incomplete) value_type's
+    // full layout in — a hard recursion for e.g. a std::variant alternative whose
+    // own completion is what triggered the query. Fall back to max_align_t instead.
+    bool         defer_alignment{ false };
 }; // struct heap_options
 
 
@@ -86,6 +93,24 @@ namespace detail
         else
             return std::uint8_t{ alignof( std::max_align_t ) };
     }
+
+    // Resolve the storage alignment with `if constexpr` (NOT a ternary): the
+    // heap_default_alignment<U>() branch must not even be *instantiated* when the
+    // caller opts out of alignof(U) via options.defer_alignment, because that
+    // instantiation evaluates complete<U> — an ODR-hazardous probe that flips to
+    // `true` on a late instantiation and drags U's full layout in (a hard
+    // recursion for a recursive strong-typedef whose completion is what asked).
+    // A ternary operand is always instantiated; `if constexpr` genuinely discards.
+    template <typename U, heap_options options>
+    consteval std::uint8_t heap_alignment() noexcept
+    {
+        if constexpr ( options.alignment )
+            return options.alignment;
+        else if constexpr ( options.defer_alignment )
+            return std::uint8_t{ alignof( std::max_align_t ) };
+        else
+            return heap_default_alignment<U>();
+    }
 } // namespace detail
 
 template <typename T, typename sz_t = std::size_t, typename Allocator = void, heap_options options = {}>
@@ -101,9 +126,10 @@ class [[ nodiscard, clang::trivial_abi ]] heap_storage
 public:
     // Use alignof(T) when T is complete; fall back to max_align_t for incomplete
     // recursive strong-typedefs so heap_storage<> never touches alignof(T) at class scope.
-    static std::uint8_t constexpr alignment{
-        options.alignment ? options.alignment : detail::heap_default_alignment<T>()
-    };
+    // With options.defer_alignment (support_incomplete_types), skip the complete<T>
+    // probe entirely — even a discarded `if constexpr (complete<T>)` can flip late
+    // and recurse into the value_type's still-forming layout (see heap_options).
+    static std::uint8_t constexpr alignment{ detail::heap_alignment<T, options>() };
 
     static bool constexpr storage_zero_initialized{ false };
     static bool constexpr fixed_sized_copy        { false }; // only true for small fixed_storage (MSVC workaround having to define this everywhere)

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -71,8 +71,8 @@ TEST( vector_traits, heap_vector_variant_growth_preserves_values )
 // (non-noexcept move-assignment) used to take the memmove shift path (slot left a
 // raw byte-duplicate) but the assign fill path (`*iter = {...}`), whose move-assign
 // destructor ran on the stale duplicate and freed the relocated element's buffer
-// -> use-after-free. (Real-world trigger: psi::vm::flat_map<string, ast::QueryFilter>
-//  where QueryFilter is a std::variant with a heap_vector alternative.)
+// -> use-after-free. (Real-world trigger: a flat_map<string, T> where T is a
+//  std::variant with a heap_vector alternative.)
 namespace {
     inline std::atomic<int> reloc_owner_net_allocs{ 0 };
     struct reloc_heap_owner {
@@ -112,6 +112,125 @@ TEST( vector_insert, middle_insert_relocates_heap_owner_without_uaf )
         EXPECT_EQ( *v[ 1 ].p, 100 );            // UAF read under the bug (ASAN traps)
     }
     EXPECT_EQ( reloc_owner_net_allocs.load(), 0 ); // bug double-frees -> ends negative
+}
+
+// Regression: is_trivially_moveable must never green-light a memmove of an STL
+// container that is not bitwise relocatable. Under Microsoft's STL with debug
+// iterators (_ITERATOR_DEBUG_LEVEL != 0) std::vector / std::string / any type
+// derived-from or transitively-containing them carry a heap-allocated
+// _Container_proxy whose _Mycont back-pointer is re-seated by the move
+// constructor but NOT by a raw memmove — so relocating them bitwise dangles the
+// proxy (crash / UAF, e.g. a flat_map<string, T> whose value T is a
+// std::variant with a std::vector alternative). At IDL==0 they are plain
+// pointer+size handles and remain trivially moveable. (Also guards llvm#69394:
+// an ABI-ignored [[clang::trivial_abi]] on a container-derived class must not
+// flip the classification.) The whole contract is compiled-checked on the MSVC
+// STL, where both the buggy and correct configurations exist.
+#if defined( _MSVC_STL_VERSION )
+namespace {
+    struct [[ clang::trivial_abi ]] vec_derived    : std::vector<int>          { using std::vector<int>::vector;          };
+    struct [[ clang::trivial_abi ]] str_wrapper     { std::string s; };
+    using variant_with_container = std::variant<std::vector<int>, std::string>;
+#if _ITERATOR_DEBUG_LEVEL != 0
+    static_assert( !is_trivially_moveable<std::vector<int>>        );
+    static_assert( !is_trivially_moveable<std::string>            );
+    static_assert( !is_trivially_moveable<variant_with_container> );
+    static_assert( !is_trivially_moveable<vec_derived>           );
+    static_assert( !is_trivially_moveable<str_wrapper>          );
+#else
+    static_assert(  is_trivially_moveable<std::vector<int>>        );
+    static_assert(  is_trivially_moveable<std::string>            );
+    static_assert(  is_trivially_moveable<variant_with_container> );
+#endif
+} // anonymous namespace
+#endif // _MSVC_STL_VERSION
+
+// Runtime companion: force BOTH relocation paths (geometric-growth realloc and
+// middle-insert shift) on a heap_vector of proxy-bearing variant payloads, then
+// read every element back THROUGH CHECKED ITERATORS (range-for), which is what
+// dereferences the container proxy under debug iterators. With the memmove fast
+// path wrongly enabled this corrupts / traps at _ITERATOR_DEBUG_LEVEL != 0; with
+// the trait corrected the elements relocate via the move constructor and stay
+// intact. At IDL==0 it simply documents the (still-correct) fast path.
+TEST( vector_insert, middle_insert_relocates_stl_container_payload )
+{
+    using payload = std::variant<std::vector<int>, std::string>;
+    heap_vector<payload, std::uint32_t> v;
+
+    // Grow (realloc-relocate) then repeatedly insert at the FRONT
+    // (shift-relocate) so every element is relocated many times over.
+    for ( std::uint32_t i{ 0 }; i < 2000; ++i )
+        v.emplace_back( std::vector<int>{ static_cast<int>( i ), static_cast<int>( i + 1 ), static_cast<int>( i + 2 ) } );
+    for ( std::uint32_t i{ 0 }; i < 2000; ++i )
+        v.emplace( v.begin(), std::to_string( i ) );
+
+    ASSERT_EQ( v.size(), 4000U );
+    // First half (after 2000 front-inserts) holds the strings in reverse; the
+    // second half holds the original vectors. Verify via range-for (checked
+    // iterators) plus per-element content.
+    std::uint32_t idx{ 0 };
+    for ( auto const & p : v ) {
+        if ( idx < 2000U ) {
+            ASSERT_TRUE( std::holds_alternative<std::string>( p ) );
+            EXPECT_EQ( std::get<std::string>( p ), std::to_string( 1999U - idx ) );
+        } else {
+            auto const orig{ idx - 2000U };
+            ASSERT_TRUE( std::holds_alternative<std::vector<int>>( p ) );
+            auto const & iv{ std::get<std::vector<int>>( p ) };
+            ASSERT_EQ( iv.size(), 3U );
+            EXPECT_EQ( iv[ 0 ], static_cast<int>( orig ) );
+            EXPECT_EQ( iv[ 2 ], static_cast<int>( orig + 2 ) );
+        }
+        ++idx;
+    }
+}
+
+// Regression: a heap_vector with support_incomplete_types=true must be usable as
+// a std::variant alternative for a RECURSIVE strong-typedef value_type while that
+// type is still incomplete — including when a by-value member of another struct
+// forces the alternative's completion (which pulls std::variant's SMF-control
+// is_trivially_{destructible,move/copy_constructible} queries in). The shape is a
+// node type N = variant<..., B, ...> where B derives from heap_vector<N> and B is
+// also embedded by value in an enclosing struct (the by-value member forces B's
+// completion). Such a recursive AST modelled on heap_vector used to fail
+// to compile because heap_storage::alignment probed complete<T> at class scope
+// (a ternary operand is always instantiated) and recursed into the still-forming
+// type. If this TU compiles at all, that recursion is broken (heap_options::
+// defer_alignment / heap_alignment()'s `if constexpr`). The runtime body also
+// exercises growth + middle-insert relocation of the recursive nodes.
+namespace incomplete_recursive_heap_vector {
+    template <typename Tag> struct Node;
+    template <typename Tag>
+    struct NodeXpr {
+        using N        = Node<Tag>;
+        using Children = heap_vector<N, std::uint32_t, heap_options{}, geometric_growth{}, /*support_incomplete_types*/ true>;
+        struct Branch : Children { using Children::Children; static constexpr bool is_trivially_moveable{ true }; };
+        using Variant  = std::variant<Tag, Branch>;
+    };
+    template <typename Tag>
+    struct Node : NodeXpr<Tag>::Variant {
+        using Variant = typename NodeXpr<Tag>::Variant;
+        using Variant::Variant;
+        Node( Node && n, bool ) noexcept : Variant{ std::move( n ) } {}
+    };
+    struct leaf { int v; };
+    using TreeNode   = Node<leaf>;
+    using TreeBranch = NodeXpr<leaf>::Branch;
+    struct Owner { TreeBranch children; }; // by-value member -> forces TreeBranch completion (the trigger)
+} // namespace incomplete_recursive_heap_vector
+
+TEST( vector_incomplete_types, recursive_heap_vector_as_variant_alternative )
+{
+    using namespace incomplete_recursive_heap_vector;
+    TreeBranch b;
+    b.emplace_back( TreeNode{ leaf{ 1 } } );
+    b.emplace( b.begin(), TreeNode{ leaf{ 2 } } ); // middle-insert relocation of the recursive nodes
+    ASSERT_EQ( b.size(), 2u );
+    Owner o{ std::move( b ) };
+    ASSERT_EQ( o.children.size(), 2u );
+    ASSERT_TRUE( std::holds_alternative<leaf>( static_cast<TreeNode::Variant const &>( o.children[ 0 ] ) ) );
+    EXPECT_EQ( std::get<leaf>( static_cast<TreeNode::Variant const &>( o.children[ 0 ] ) ).v, 2 );
+    EXPECT_EQ( std::get<leaf>( static_cast<TreeNode::Variant const &>( o.children[ 1 ] ) ).v, 1 );
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Two independent container-robustness fixes, both surfaced by a downstream project (farseer) migrating a recursive AST onto `heap_vector` under clang-cl + Microsoft STL with `_ITERATOR_DEBUG_LEVEL=1`.

## 1. `is_trivially_moveable`: MSVC debug-iterator containers are not bitwise-relocatable

At `_ITERATOR_DEBUG_LEVEL != 0`, MSVC's `std::vector` / `std::basic_string` carry a heap-allocated `_Container_proxy` whose `_Mycont` back-pointer is re-seated by the **move constructor** but **not** by a raw `memmove`. Relocating them bitwise strands the proxy (dangling `_Mycont`, or a shared-proxy double-free when the moved-from slot is later touched/destroyed).

Separately, Clang's relocatability builtins are unreliable under the Windows ABI ([llvm#69394](https://github.com/llvm/llvm-project/issues/69394)) and report such types trivially relocatable even when a class merely *derives* from a debug container, or when an ABI-ignored `[[clang::trivial_abi]]` leaks through `__is_trivially_relocatable`.

Fix: under `_MSVC_STL_VERSION && _ITERATOR_DEBUG_LEVEL != 0` (mirroring the existing `_LIBCPP_DEBUG` handling), drop the Clang relocatability builtins from the primary template and drop the `std::vector`/`std::basic_string` fast-path specializations — falling back to the honest core triviality traits (which are false for any proxy-bearing type). Release (`IDL==0`) is unchanged; the bitwise fast path is retained.

## 2. `heap_storage` alignment under `support_incomplete_types`

The class-scope `alignment` constant resolved `alignof(T)` via a **ternary** whose discarded operand (`heap_default_alignment<T>()`) is still instantiated and probes `complete<T>`. That probe is an ODR hazard: it can flip to `true` on a late instantiation and pull an incomplete recursive `value_type`'s full layout in — a hard compile-time recursion when the type is a `std::variant` alternative whose own completion triggered the query. This is what blocked using `heap_vector` for a recursive AST.

Fix: add `heap_options::defer_alignment`, thread it from `heap_vector`'s `support_incomplete_types`, and resolve `alignment` through an `if constexpr` `heap_alignment()` helper that never instantiates the `alignof(T)` branch when deferring.

## Tests (`test/vector.cpp`)
- `vector_traits` static-asserts + `vector_insert.middle_insert_relocates_stl_container_payload` — the MSVC debug-iterator relocation contract (proxy-bearing types are non-relocatable at IDL≥1, relocatable at IDL==0).
- `vector_incomplete_types.recursive_heap_vector_as_variant_alternative` — compiles a recursive `heap_vector`-in-`variant` embedded by value; if the TU compiles the alignment recursion is broken. Also exercises growth + middle-insert relocation of the recursive nodes.

Full `vm_unit_tests` suite passes (2008/2008) on clang-cl / MSVC STL at `_ITERATOR_DEBUG_LEVEL=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)